### PR TITLE
Service queue integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+MQ_USER=Username for RabbitMQ
+MQ_PASS=Password for RabbitMQ

--- a/README.md
+++ b/README.md
@@ -1,15 +1,27 @@
 profile_service
 
 # Installation
-This app/solution can be run in 2 different environments
+This app/solution can be run in 2 different environments. 
+
+## Configuration
+To configure this application there are 2 files that require mondifcation.
+
+1. `./src/config.js`
+
+    This file contains the majority of the variables that define the diference between your production, development, and test environments that are not secrets.
+
+2. `./.env`
+
+    This file contains the secrets required for the application and can be set eitehr through ENV variables or through this file.
+* `MQ_USER` = Username for RabbitMQ instance set in `./src/config.js`
+* `MQ_PASS` = Password for RabbitMQ instance
 
 ## Development
 To setup this application in development run the following commands:
 
 * `sudo docker-compose -f docker-compose-dev.yml up`
 * `sudo npm install`
-* `cd prisma && yarn prisma deploy && cd ..`
-* `NODE_ENV=development PRISMA_API_ENDPOINT=localhost node ./src/cluster.js`
+* `npm start dev`
 
 The profile as a service playground endpoint can now be reached at http://localhost:4000/playground and the graphql endpoint at http://localhost:4000/graphql
 The prisma service can be reached at http://localhost:4466/profile
@@ -24,8 +36,8 @@ The profile as a service playground endpoint can now be reached at http://localh
 
 # Tests
 To run tests from the root of the project:
-`sudo docker-compose -f docker-compose-test.yml up -d`
-`npm test`
+* `sudo docker-compose -f docker-compose-test.yml up -d`
+* `npm test`
 
 # Validation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -421,6 +421,42 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
       "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
     },
+    "amqplib": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.5.3.tgz",
+      "integrity": "sha512-ZOdUhMxcF+u62rPI+hMtU1NBXSDFQ3eCJJrenamtdQ7YYwh7RZJHOIM1gonVbZ5PyVdYH4xqBPje9OYqk7fnqw==",
+      "requires": {
+        "bitsyntax": "~0.1.0",
+        "bluebird": "^3.5.2",
+        "buffer-more-ints": "~1.0.0",
+        "readable-stream": "1.x >=1.1.9",
+        "safe-buffer": "~5.1.2",
+        "url-parse": "~1.4.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
     "ansi-align": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
@@ -1395,6 +1431,31 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
       "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew=="
     },
+    "bitsyntax": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bitsyntax/-/bitsyntax-0.1.0.tgz",
+      "integrity": "sha512-ikAdCnrloKmFOugAfxWws89/fPc+nw0OOG1IzIE72uSOg/A3cYptKCjSUhDTuj7fhsJtzkzlv7l3b8PzRHLN0Q==",
+      "requires": {
+        "buffer-more-ints": "~1.0.0",
+        "debug": "~2.6.9",
+        "safe-buffer": "~5.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "bl": {
       "version": "1.2.2",
       "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -1584,6 +1645,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "buffer-more-ints": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
+      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg=="
     },
     "buffer-writer": {
       "version": "2.0.0",
@@ -8113,6 +8179,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
+    "querystringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
+      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
+    },
     "randomatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
@@ -8392,6 +8463,11 @@
           "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
         }
       }
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.1.7",
@@ -9842,6 +9918,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
       "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo="
+    },
+    "url-parse": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+      "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
+      "requires": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      }
     },
     "url-parse-lax": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,95 +127,6 @@
       "resolved": "https://registry.npmjs.org/@heroku/linewrap/-/linewrap-1.0.0.tgz",
       "integrity": "sha512-qPeQp2DnALUwWKaL6ZXfnOw/lHp+zNg5V8whx5c/Y10HMWYjuQFqKupgoJgyuEYjnvYwoZTarW280+aOXWQLCQ=="
     },
-    "@kbrandwijk/swagger-to-graphql": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@kbrandwijk/swagger-to-graphql/-/swagger-to-graphql-2.4.3.tgz",
-      "integrity": "sha512-CNVsCrMge/jq6DCT5buNZ8PACY9RTvPJbCNoIcndfkJOCsNxOx9dnc5qw4pHZdHi8GS6l3qlgkuFKp33iD8J2Q==",
-      "requires": {
-        "babel-runtime": "^6.25.0",
-        "isomorphic-fetch": "^2.2.1",
-        "js-yaml": "^3.8.4",
-        "json-schema-ref-parser": "^3.1.2",
-        "lodash": "^4.16.4",
-        "node-request-by-swagger": "^1.0.6",
-        "request": "^2.75.0",
-        "request-promise": "^4.1.1",
-        "yargs": "^8.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "yargs": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-          "requires": {
-            "camelcase": "^4.1.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "read-pkg-up": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^7.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-          "requires": {
-            "camelcase": "^4.1.0"
-          }
-        }
-      }
-    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -387,9 +298,9 @@
       "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA=="
     },
     "@types/mongodb": {
-      "version": "3.1.17",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.1.17.tgz",
-      "integrity": "sha512-u6tSIpfdsgK74aE0TuyqZYhHscw+gHs6dQNSsFUTFXubhhxCqovmV3nJRS0YKSw0sfqbzUgGzbG5+yorUPRnFg==",
+      "version": "3.1.19",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.1.19.tgz",
+      "integrity": "sha512-H54hQEovAhyLrIZOhPNfGyCCDoTqKsjb8GQBy8nptJqfxrYCp5WVcPJf9v0kfTPR72xOhaz9+WcYxOXWwEg1Vg==",
       "requires": {
         "@types/bson": "*",
         "@types/node": "*"
@@ -438,6 +349,13 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
       "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
       "dev": true
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "optional": true
     },
     "accepts": {
       "version": "1.3.5",
@@ -559,135 +477,6 @@
           "integrity": "sha512-8TUgIIUVpXWOcqq9RdmTSHUrhc3a/s+saKv9cCl8TYWHK9vyJIdea7ZaSKHGDthZNcsN+C3LulZYRL3Ah8ukoA==",
           "requires": {
             "@apollographql/apollo-tools": "^0.2.6"
-          }
-        }
-      }
-    },
-    "apollo-codegen": {
-      "version": "0.19.1",
-      "resolved": "http://registry.npmjs.org/apollo-codegen/-/apollo-codegen-0.19.1.tgz",
-      "integrity": "sha512-jlxz/b5iinRWfh48hXdmMtrjTPn/rDok0Z3b7icvkiaD6I30w4sq9B+JDkFbLnkldzsFLV2BZtBDa/dkZhx8Ng==",
-      "requires": {
-        "@babel/generator": "7.0.0-beta.38",
-        "@babel/types": "7.0.0-beta.38",
-        "change-case": "^3.0.1",
-        "common-tags": "^1.5.1",
-        "core-js": "^2.5.3",
-        "glob": "^7.1.2",
-        "graphql": "^0.13.1",
-        "graphql-config": "^1.1.1",
-        "inflected": "^2.0.3",
-        "node-fetch": "^1.7.3",
-        "rimraf": "^2.6.2",
-        "source-map-support": "^0.5.0",
-        "yargs": "^10.0.3"
-      },
-      "dependencies": {
-        "@babel/generator": {
-          "version": "7.0.0-beta.38",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.38.tgz",
-          "integrity": "sha512-aOHQPhsEyaB6p2n+AK981+onHoc+Ork9rcAQVSUJR33wUkGiWRpu6/C685knRyIZVsKeSdG5Q4xMiYeFUhuLzA==",
-          "requires": {
-            "@babel/types": "7.0.0-beta.38",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.2.0",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/types": {
-          "version": "7.0.0-beta.38",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.38.tgz",
-          "integrity": "sha512-SAtyEjmA7KiEoL2eAOAUM6M9arQJGWxJKK0S9x0WyPOosHS420RXoxPhn57u/8orRnK8Kxm0nHQQNTX203cP1Q==",
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.2.0",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "core-js": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.1.tgz",
-          "integrity": "sha512-L72mmmEayPJBejKIWe2pYtGis5r0tQ5NaJekdhyXgeMQTpJoBsH0NL4ElY2LfSoV15xeQWKQ+XTTOZdyero5Xg=="
-        },
-        "graphql": {
-          "version": "0.13.2",
-          "resolved": "http://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
-          "integrity": "sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==",
-          "requires": {
-            "iterall": "^1.2.1"
-          }
-        },
-        "graphql-config": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-1.2.1.tgz",
-          "integrity": "sha512-BOtbEOn/fD13jT0peCy3Fzp1DSTsA/1AcZp266AQ5Sk3wFndKCEa/H7donbu5UriOw1V/N1WDirYPnr7rd8E7Q==",
-          "requires": {
-            "graphql": "^0.12.3",
-            "graphql-import": "^0.4.0",
-            "graphql-request": "^1.4.0",
-            "js-yaml": "^3.10.0",
-            "lodash": "^4.17.4",
-            "minimatch": "^3.0.4"
-          },
-          "dependencies": {
-            "graphql": {
-              "version": "0.12.3",
-              "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.12.3.tgz",
-              "integrity": "sha512-Hn9rdu4zacplKXNrLCvR8YFiTGnbM4Zw/UH8FDmzBDsH7ou40lSNH4tIlsxcYnz2TGNVJCpu1WxCM23yd6kzhA==",
-              "requires": {
-                "iterall": "1.1.3"
-              }
-            },
-            "iterall": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.1.3.tgz",
-              "integrity": "sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ=="
-            }
-          }
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        },
-        "source-map-support": {
-          "version": "0.5.9",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-          "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-            }
-          }
-        },
-        "yargs": {
-          "version": "10.1.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-          "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
-          "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^8.1.0"
           }
         }
       }
@@ -1435,6 +1224,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -1443,7 +1233,8 @@
         "core-js": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.0.tgz",
-          "integrity": "sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw=="
+          "integrity": "sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw==",
+          "dev": true
         }
       }
     },
@@ -1723,6 +1514,11 @@
         "resolve": "1.1.7"
       }
     },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+    },
     "bs-logger": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
@@ -1797,7 +1593,8 @@
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
     },
     "busboy": {
       "version": "0.2.14",
@@ -1922,31 +1719,6 @@
         "supports-color": "^5.3.0"
       }
     },
-    "change-case": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.0.2.tgz",
-      "integrity": "sha512-Mww+SLF6MZ0U6kdg11algyKd5BARbyM4TbFBepwowYSR5ClfQGCGtxNXgykpN0uF/bstWeaGDT4JWaDh8zWAHA==",
-      "requires": {
-        "camel-case": "^3.0.0",
-        "constant-case": "^2.0.0",
-        "dot-case": "^2.1.0",
-        "header-case": "^1.0.0",
-        "is-lower-case": "^1.1.0",
-        "is-upper-case": "^1.1.0",
-        "lower-case": "^1.1.1",
-        "lower-case-first": "^1.0.0",
-        "no-case": "^2.3.2",
-        "param-case": "^2.1.0",
-        "pascal-case": "^2.0.0",
-        "path-case": "^2.1.0",
-        "sentence-case": "^2.1.0",
-        "snake-case": "^2.1.0",
-        "swap-case": "^1.1.0",
-        "title-case": "^2.1.0",
-        "upper-case": "^1.1.1",
-        "upper-case-first": "^1.1.0"
-      }
-    },
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
@@ -2014,11 +1786,6 @@
         "restore-cursor": "^2.0.0"
       }
     },
-    "cli-spinners": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
-      "integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg=="
-    },
     "cli-table": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
@@ -2077,11 +1844,6 @@
         "wrap-ansi": "^2.0.0"
       }
     },
-    "clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-    },
     "cluster": {
       "version": "0.7.7",
       "resolved": "http://registry.npmjs.org/cluster/-/cluster-0.7.7.tgz",
@@ -2095,6 +1857,22 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "codacy-coverage": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/codacy-coverage/-/codacy-coverage-3.4.0.tgz",
+      "integrity": "sha512-A0ats3/gZtOw76muu++HZ6QrInztWjjLefkLJmmBpjPfyn6nNwNLoApmGmj3F3dfgl2+o6u5GwPnUBkKdfKXTQ==",
+      "requires": {
+        "bluebird": "^3.5.x",
+        "commander": "^2.x",
+        "jacoco-parse": "^2.x",
+        "joi": "^13.x",
+        "lcov-parse": "^1.x",
+        "lodash": "^4.17.4",
+        "log-driver": "^1.x",
+        "request": "^2.88.0",
+        "request-promise": "^4.x"
+      }
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -2146,30 +1924,6 @@
       "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
-    "columnify": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
-      "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
-      "requires": {
-        "strip-ansi": "^3.0.0",
-        "wcwidth": "^1.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
-      }
-    },
     "combined-stream": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
@@ -2178,20 +1932,10 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "command-exists": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.8.tgz",
-      "integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw=="
-    },
     "commander": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
       "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
-    },
-    "common-tags": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -2242,15 +1986,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-    },
-    "constant-case": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
-      "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
-      "requires": {
-        "snake-case": "^2.1.0",
-        "upper-case": "^1.1.1"
-      }
     },
     "content-disposition": {
       "version": "0.5.2",
@@ -2303,17 +2038,6 @@
       "requires": {
         "object-assign": "^4",
         "vary": "^1"
-      }
-    },
-    "cosmiconfig": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
-      "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
-      "requires": {
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "parse-json": "^3.0.0",
-        "require-from-string": "^2.0.1"
       }
     },
     "crc": {
@@ -2392,39 +2116,6 @@
       "dev": true,
       "requires": {
         "cssom": "0.3.x"
-      }
-    },
-    "cucumber-html-reporter": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/cucumber-html-reporter/-/cucumber-html-reporter-3.0.4.tgz",
-      "integrity": "sha512-uit68jymdI8Z6m+kJ5YnJPeHf5IdYXt2j52l5xLwgpcLBQRhCvr1peV9UODaCN5nLnRN9nqh1qaw4iNp1rTpvQ==",
-      "requires": {
-        "find": "^0.2.7",
-        "fs-extra": "^3.0.1",
-        "js-base64": "^2.3.2",
-        "jsonfile": "^3.0.0",
-        "lodash": "^4.17.2",
-        "open": "0.0.5"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
-          "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^3.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-          "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        }
       }
     },
     "d": {
@@ -2532,14 +2223,6 @@
             "is-utf8": "^0.2.0"
           }
         }
-      }
-    },
-    "defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "requires": {
-        "clone": "^1.0.2"
       }
     },
     "define-properties": {
@@ -2694,30 +2377,9 @@
       }
     },
     "directory-tree": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/directory-tree/-/directory-tree-2.2.0.tgz",
-      "integrity": "sha512-ZHQDIK7NHy0xokdR9sE0h+YfN2unwjLK6CwofJ6NpMuQVEcTZqjTeiTgmx60ieJkngZYkVFAVGiihE4hwpkJeQ=="
-    },
-    "disparity": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/disparity/-/disparity-2.0.0.tgz",
-      "integrity": "sha1-V92stHMkrl9Y0swNqIbbTOnutxg=",
-      "requires": {
-        "ansi-styles": "^2.0.1",
-        "diff": "^1.3.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "diff": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-          "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
-        }
-      }
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/directory-tree/-/directory-tree-2.2.1.tgz",
+      "integrity": "sha512-AWgnCDEKC2/oSAA/0Ae3RhXnMkvOZtNAVQu7wF2/qXF5Xm8LhjWnEXLV4Yza45SmWkNPvNlo4zWPhZjcVd4T5w=="
     },
     "doctrine": {
       "version": "2.1.0",
@@ -2734,14 +2396,6 @@
       "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
-      }
-    },
-    "dot-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
-      "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
-      "requires": {
-        "no-case": "^2.2.0"
       }
     },
     "dot-prop": {
@@ -2817,6 +2471,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       },
@@ -2824,7 +2479,8 @@
         "is-arrayish": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "dev": true
         }
       }
     },
@@ -3195,14 +2851,6 @@
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
     },
-    "expand-tilde": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-      "requires": {
-        "homedir-polyfill": "^1.0.1"
-      }
-    },
     "expect": {
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-23.6.0.tgz",
@@ -3439,9 +3087,9 @@
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-glob": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.4.tgz",
-      "integrity": "sha512-FjK2nCGI/McyzgNtTESqaWP3trPvHyRyoyY70hxjc3oKPNmDe8taohLZpoVKoUjW85tbU5txaYUZCNtVzygl1g==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz",
+      "integrity": "sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==",
       "requires": {
         "@mrmlnc/readdir-enhanced": "^2.2.1",
         "@nodelib/fs.stat": "^1.1.2",
@@ -3553,22 +3201,6 @@
         }
       }
     },
-    "find": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/find/-/find-0.2.9.tgz",
-      "integrity": "sha1-S3Px/55WrZG3bnFkB/5f/mVUu4w=",
-      "requires": {
-        "traverse-chain": "~0.1.0"
-      }
-    },
-    "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-      "requires": {
-        "locate-path": "^2.0.0"
-      }
-    },
     "flat-cache": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
@@ -3613,11 +3245,6 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
-    },
-    "format-util": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
-      "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -3676,532 +3303,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.6.tgz",
+      "integrity": "sha512-BalK54tfK0pMC0jQFb2oHn1nz7JNQD/2ex5pBnCHgBi2xG7VV0cAOGy2RS2VbCqUXx5/6obMrMcQTJ8yjcGzbg==",
       "dev": true,
       "optional": true,
       "requires": {
         "nan": "^2.9.2",
         "node-pre-gyp": "^0.10.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.21",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": "^2.1.0"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "minipass": {
-          "version": "2.2.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.10.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.1.10",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        }
       }
     },
     "function-bind": {
@@ -4371,40 +3480,18 @@
         "ini": "^1.3.4"
       }
     },
-    "global-modules": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-      "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
-      }
-    },
-    "global-prefix": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-      "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
-      }
-    },
     "globals": {
       "version": "11.9.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
       "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg=="
     },
     "globby": {
-      "version": "8.0.1",
-      "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
-      "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+      "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
       "requires": {
         "array-union": "^1.0.1",
-        "dir-glob": "^2.0.0",
+        "dir-glob": "2.0.0",
         "fast-glob": "^2.0.2",
         "glob": "^7.1.2",
         "ignore": "^3.3.5",
@@ -4447,235 +3534,12 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
-    "graphcool-json-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/graphcool-json-schema/-/graphcool-json-schema-1.2.1.tgz",
-      "integrity": "sha1-bO+2yLUFQ2FebvpDu1T54/uygfM="
-    },
-    "graphcool-yml": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/graphcool-yml/-/graphcool-yml-0.4.15.tgz",
-      "integrity": "sha512-ZVbRfVI8l21+1JQkcG0XuRam9mgiVUh9/PIcluzCZca2+lZQg/e1WCDXpwsC69i2ZdPcZwpOCLFKQMg5rnulCA==",
-      "requires": {
-        "ajv": "^5.5.1",
-        "bluebird": "^3.5.1",
-        "debug": "^3.1.0",
-        "dotenv": "^4.0.0",
-        "fs-extra": "^4.0.3",
-        "graphcool-json-schema": "1.2.1",
-        "isomorphic-fetch": "^2.2.1",
-        "js-yaml": "^3.10.0",
-        "json-stable-stringify": "^1.0.1",
-        "jsonwebtoken": "^8.1.0",
-        "lodash": "^4.17.4",
-        "replaceall": "^0.1.6",
-        "scuid": "^1.0.2",
-        "yaml-ast-parser": "^0.0.40"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
-          }
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "dotenv": {
-          "version": "4.0.0",
-          "resolved": "http://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-          "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-        },
-        "fs-extra": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-        }
-      }
-    },
     "graphql": {
       "version": "14.0.2",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.0.2.tgz",
       "integrity": "sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==",
       "requires": {
         "iterall": "^1.2.2"
-      }
-    },
-    "graphql-cli": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/graphql-cli/-/graphql-cli-2.17.0.tgz",
-      "integrity": "sha512-K82gG79pA3G8GzMeqFq5+kkdZi7K6UWlvmrWLuGaIvo8F1wdHAKDvfexjRGb5CPisqAJqQqbsGsfrg7If488kA==",
-      "requires": {
-        "adm-zip": "0.4.7",
-        "apollo-codegen": "^0.19.1",
-        "chalk": "^2.3.1",
-        "command-exists": "^1.2.2",
-        "cross-spawn": "^6.0.5",
-        "disparity": "^2.0.0",
-        "dotenv": "^5.0.0",
-        "express": "^4.16.2",
-        "express-request-proxy": "^2.0.0",
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0",
-        "graphql-cli-prepare": "1.4.19",
-        "graphql-config": "2.2.1",
-        "graphql-config-extension-graphcool": "1.0.11",
-        "graphql-config-extension-prisma": "0.2.5",
-        "graphql-playground-middleware-express": "1.7.6",
-        "graphql-schema-linter": "0.1.1",
-        "inquirer": "5.1.0",
-        "is-url-superb": "2.0.0",
-        "js-yaml": "^3.10.0",
-        "lodash": "^4.17.5",
-        "mkdirp": "^0.5.1",
-        "node-fetch": "^2.0.0",
-        "npm-paths": "^1.0.0",
-        "npm-run": "4.1.2",
-        "opn": "^5.2.0",
-        "ora": "^1.4.0",
-        "parse-github-url": "^1.0.2",
-        "request": "^2.83.0",
-        "rimraf": "2.6.2",
-        "source-map-support": "^0.5.3",
-        "tmp-graphql-config-extension-openapi": "^1.0.7",
-        "update-notifier": "^2.3.0",
-        "yargs": "11.0.0"
-      },
-      "dependencies": {
-        "adm-zip": {
-          "version": "0.4.7",
-          "resolved": "http://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
-          "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E="
-        },
-        "chardet": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
-        },
-        "dotenv": {
-          "version": "5.0.1",
-          "resolved": "http://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
-          "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
-        },
-        "external-editor": {
-          "version": "2.2.0",
-          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-          "requires": {
-            "chardet": "^0.4.0",
-            "iconv-lite": "^0.4.17",
-            "tmp": "^0.0.33"
-          }
-        },
-        "graphql": {
-          "version": "0.13.2",
-          "resolved": "http://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
-          "integrity": "sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==",
-          "requires": {
-            "iterall": "^1.2.1"
-          }
-        },
-        "inquirer": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.1.0.tgz",
-          "integrity": "sha512-kn7N70US1MSZHZHSGJLiZ7iCwwncc7b0gc68YtlX29OjI3Mp0tSVV+snVXpZ1G+ONS3Ac9zd1m6hve2ibLDYfA==",
-          "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.0",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^2.1.0",
-            "figures": "^2.0.0",
-            "lodash": "^4.3.0",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rxjs": "^5.5.2",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^4.0.0",
-            "through": "^2.3.6"
-          }
-        },
-        "rxjs": {
-          "version": "5.5.12",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-          "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-          "requires": {
-            "symbol-observable": "1.0.1"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "source-map-support": {
-          "version": "0.5.9",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-          "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-          }
-        },
-        "symbol-observable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
-        }
-      }
-    },
-    "graphql-cli-prepare": {
-      "version": "1.4.19",
-      "resolved": "https://registry.npmjs.org/graphql-cli-prepare/-/graphql-cli-prepare-1.4.19.tgz",
-      "integrity": "sha512-PJFm9/DvfZwKz3h2Wyn/5Sr/sX35XsYzNO3olfm5V8qqueNIONI0g7sVqpF7wYdvhEtt/8YA9DjgrGclCbpMfA==",
-      "requires": {
-        "chalk": "2.3.1",
-        "fs-extra": "5.0.0",
-        "graphql-import": "0.4.5",
-        "graphql-static-binding": "0.9.3",
-        "lodash": "4.17.5"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.3.1",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
-          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.2.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
-        }
       }
     },
     "graphql-config": {
@@ -4706,15 +3570,6 @@
         }
       }
     },
-    "graphql-config-extension-graphcool": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/graphql-config-extension-graphcool/-/graphql-config-extension-graphcool-1.0.11.tgz",
-      "integrity": "sha512-uNhyMqj30M4KLkD/gGEEr6cPuVX/jtm0C9O5Bj9V2jFhN5IdHXWJx+fC/p/xxh82iOuR8uibKNCXzwA7R6F6IA==",
-      "requires": {
-        "graphcool-yml": "0.4.15",
-        "graphql-config": "2.2.1"
-      }
-    },
     "graphql-config-extension-prisma": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/graphql-config-extension-prisma/-/graphql-config-extension-prisma-0.2.5.tgz",
@@ -4730,14 +3585,6 @@
       "integrity": "sha512-Xei4rBxbsTHU6dYiq9y1xxbpRMU3+Os7yD3vXV5W4HbTaxRMizDmu6LAvV4oBEi0ttwICHARQjYTjDTDhHnxrQ==",
       "requires": {
         "@apollographql/apollo-tools": "^0.2.6"
-      }
-    },
-    "graphql-import": {
-      "version": "0.4.5",
-      "resolved": "http://registry.npmjs.org/graphql-import/-/graphql-import-0.4.5.tgz",
-      "integrity": "sha512-G/+I08Qp6/QGTb9qapknCm3yPHV0ZL7wbaalWFpxsfR8ZhZoTBe//LsbsCKlbALQpcMegchpJhpTSKiJjhaVqQ==",
-      "requires": {
-        "lodash": "^4.17.4"
       }
     },
     "graphql-playground-html": {
@@ -4762,39 +3609,6 @@
       "integrity": "sha512-dDX2M+VMsxXFCmUX0Vo0TopIZIX4ggzOtiCsThgtrKR4niiaagsGTDIHj3fsOMFETpa064vzovI+4YV4QnMbcg==",
       "requires": {
         "cross-fetch": "2.2.2"
-      }
-    },
-    "graphql-schema-linter": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/graphql-schema-linter/-/graphql-schema-linter-0.1.1.tgz",
-      "integrity": "sha512-caZbOgNw08/9p3a+qusmaFi1TklG9ti+KHI6a2yfdp009gyoClWGQ+ElKVIiZkJQSeWCri2s2UFBCZjoM0JwTw==",
-      "requires": {
-        "chalk": "^2.0.1",
-        "columnify": "^1.5.4",
-        "commander": "^2.11.0",
-        "cosmiconfig": "^3.1.0",
-        "figures": "^2.0.0",
-        "glob": "^7.1.2",
-        "graphql": "^0.13.0",
-        "lodash": "^4.17.4"
-      },
-      "dependencies": {
-        "graphql": {
-          "version": "0.13.2",
-          "resolved": "http://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
-          "integrity": "sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==",
-          "requires": {
-            "iterall": "^1.2.1"
-          }
-        }
-      }
-    },
-    "graphql-static-binding": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/graphql-static-binding/-/graphql-static-binding-0.9.3.tgz",
-      "integrity": "sha512-C8+EqwNCiQxUhbrWEokxN16oINAkhIDBzEpKHXeatBRaAyMczXm0J6HMaMSKOuQmk7P1PbDHIVW3FVZwXF2WJQ==",
-      "requires": {
-        "cucumber-html-reporter": "^3.0.4"
       }
     },
     "graphql-subscriptions": {
@@ -4851,6 +3665,11 @@
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
         }
       }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
     },
     "growly": {
       "version": "1.3.0",
@@ -4970,14 +3789,15 @@
         }
       }
     },
-    "header-case": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
-      "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
-      "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.3"
-      }
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+    },
+    "hoek": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -4989,18 +3809,11 @@
         "os-tmpdir": "^1.0.1"
       }
     },
-    "homedir-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-      "requires": {
-        "parse-passwd": "^1.0.0"
-      }
-    },
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
@@ -5103,6 +3916,16 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
+    "ignore-walk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "import-lazy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
@@ -5122,11 +3945,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-    },
-    "inflected": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inflected/-/inflected-2.0.4.tgz",
-      "integrity": "sha512-HQPzFLTTUvwfeUH6RAGjD8cHS069mBqXG5n4qaxX7sJXBhVQrsGgF+0ZJGkSuN6a8pcUWB/GXStta11kKi/WvA=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -5191,16 +4009,6 @@
         "loose-envify": "^1.0.0"
       }
     },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-    },
-    "ip-regex": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
-      "integrity": "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0="
-    },
     "ipaddr.js": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
@@ -5238,6 +4046,7 @@
       "version": "1.0.0",
       "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
       "requires": {
         "builtin-modules": "^1.0.0"
       }
@@ -5294,11 +4103,6 @@
           "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
         }
       }
-    },
-    "is-directory": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -5360,14 +4164,6 @@
       "requires": {
         "global-dirs": "^0.1.0",
         "is-path-inside": "^1.0.0"
-      }
-    },
-    "is-lower-case": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
-      "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
-      "requires": {
-        "lower-case": "^1.1.0"
       }
     },
     "is-npm": {
@@ -5467,22 +4263,6 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
-    "is-upper-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
-      "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
-      "requires": {
-        "upper-case": "^1.1.0"
-      }
-    },
-    "is-url-superb": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-2.0.0.tgz",
-      "integrity": "sha1-tyihjPaS5NFtprlMdAioEdsNBJI=",
-      "requires": {
-        "url-regex": "^3.0.0"
-      }
-    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -5503,6 +4283,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isemail": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "requires": {
+        "punycode": "2.x.x"
+      }
     },
     "isexe": {
       "version": "2.0.0",
@@ -5665,6 +4453,15 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
       "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
+    },
+    "jacoco-parse": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jacoco-parse/-/jacoco-parse-2.0.0.tgz",
+      "integrity": "sha512-bKneBFwHF+afsH1ByniUyjDCwiYhb2RYk7aovcNgOKqbayVgDQ1U9h5Fy/PMGI9/iJwIuc3yqpZvEtqY6s81lQ==",
+      "requires": {
+        "mocha": "^5.2.0",
+        "xml2js": "^0.4.9"
+      }
     },
     "jest": {
       "version": "23.6.0",
@@ -6827,10 +5624,15 @@
         "merge-stream": "^1.0.1"
       }
     },
-    "js-base64": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.0.tgz",
-      "integrity": "sha512-wlEBIZ5LP8usDylWbDNhKPEFVFdI5hCHpnVoT/Ysvoi/PRhJENm/Rlh9TvjYB38HFfKZN7OzEbRjmjvLkFw11g=="
+    "joi": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+      "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
+      "requires": {
+        "hoek": "5.x.x",
+        "isemail": "3.x.x",
+        "topo": "3.x.x"
+      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -6905,35 +5707,13 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-ref-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-3.3.1.tgz",
-      "integrity": "sha512-stQTMhec2R/p2L9dH4XXRlpNCP0mY8QrLd/9Kl+8SHJQmwHtE1nDfXH4wbsSM+GkJMl8t92yZbI0OIol432CIQ==",
-      "requires": {
-        "call-me-maybe": "^1.0.1",
-        "debug": "^3.0.0",
-        "es6-promise": "^4.1.1",
-        "js-yaml": "^3.9.1",
-        "ono": "^4.0.2",
-        "z-schema": "^3.18.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -7058,13 +5838,10 @@
         "readable-stream": "^2.0.5"
       }
     },
-    "lcid": {
+    "lcov-parse": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "requires": {
-        "invert-kv": "^1.0.0"
-      }
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
+      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A="
     },
     "left-pad": {
       "version": "1.3.0",
@@ -7087,36 +5864,6 @@
         "type-check": "~0.3.2"
       }
     },
-    "load-json-file": {
-      "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        }
-      }
-    },
-    "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
-      }
-    },
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
@@ -7126,11 +5873,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.ary/-/lodash.ary-4.1.1.tgz",
       "integrity": "sha1-ZgZfqRusx6A02cj85S+D08fkAhI="
-    },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -7186,11 +5928,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.isinteger": {
       "version": "4.0.4",
@@ -7273,13 +6010,10 @@
         "event-emitter": "^0.3.5"
       }
     },
-    "log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-      "requires": {
-        "chalk": "^2.0.1"
-      }
+    "log-driver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
     },
     "long": {
       "version": "4.0.0",
@@ -7299,14 +6033,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
-    },
-    "lower-case-first": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
-      "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
-      "requires": {
-        "lower-case": "^1.1.2"
-      }
     },
     "lowercase-keys": {
       "version": "1.0.1",
@@ -7386,15 +6112,16 @@
       "integrity": "sha512-fdZvBa7/vSQIZCi4uuwo2N3q+7jJURpMVCcbaX0S1Mg65WZ5ilXvC67MviJAsdjqqgD+CEq4RKo5AYGgINkVAA=="
     },
     "marked-terminal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-3.1.1.tgz",
-      "integrity": "sha512-7UBFww1rdx0w9HehLMCVYa8/AxXaiDigDfMsJcj82/wgLQG9cj+oiMAVlJpeWD57VFJY2OYY+bKeEVIjIlxi+w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-3.2.0.tgz",
+      "integrity": "sha512-Yr1yVS0BbDG55vx7be1D0mdv+jGs9AW563o/Tt/7FTsId2J0yqhrTeXAqq/Q0DyyXltIn6CSxzesQuFqXgafjQ==",
       "requires": {
+        "ansi-escapes": "^3.1.0",
         "cardinal": "^2.1.1",
         "chalk": "^2.4.1",
         "cli-table": "^0.3.1",
-        "lodash.assign": "^4.2.0",
-        "node-emoji": "^1.4.1"
+        "node-emoji": "^1.4.1",
+        "supports-hyperlinks": "^1.0.1"
       },
       "dependencies": {
         "ansicolors": {
@@ -7442,18 +6169,10 @@
       "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
-    "mem": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "requires": {
-        "mimic-fn": "^1.0.0"
-      }
-    },
     "memory-pager": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.3.1.tgz",
-      "integrity": "sha512-pUf/sGkym2WqFZYTVmdASnSbNfpGc9rwxEHOePx4lT/fD+NHGL1U16Uy4o6PMiVcDv4mp6MI/vaF0c/Kd1QEUQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
       "optional": true
     },
     "merge": {
@@ -7598,19 +6317,78 @@
         "minimist": "0.0.8"
       }
     },
-    "mongodb": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.10.tgz",
-      "integrity": "sha512-Uml42GeFxhTGQVml1XQ4cD0o/rp7J2ROy0fdYUcVitoE7vFqEhKH4TYVqRDpQr/bXtCJVxJdNQC1ntRxNREkPQ==",
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
       "requires": {
-        "mongodb-core": "3.1.9",
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "mongodb": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.12.tgz",
+      "integrity": "sha512-JJnxDoaObL+U+TLo4A17yGe7vdRK8p8dh1MqxG9V9AFTZz13WoAXSMpT1kELUIyPCNaf0S0gW1EROPhmXVCgwg==",
+      "requires": {
+        "mongodb-core": "3.1.11",
         "safe-buffer": "^5.1.2"
       }
     },
     "mongodb-core": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.9.tgz",
-      "integrity": "sha512-MJpciDABXMchrZphh3vMcqu8hkNf/Mi+Gk6btOimVg1XMxLXh87j6FAvRm+KmwD1A9fpu3qRQYcbQe4egj23og==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.11.tgz",
+      "integrity": "sha512-rD2US2s5qk/ckbiiGFHeu+yKYDXdJ1G87F6CG3YdaZpzdOm5zpoAZd/EKbPmFO6cQZ+XVXBXBJ660sSI0gc6qg==",
       "requires": {
         "bson": "^1.1.0",
         "require_optional": "^1.0.1",
@@ -7676,6 +6454,37 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+    },
+    "needle": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
+      "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "debug": "^2.1.2",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "negotiator": {
       "version": "0.6.1",
@@ -7744,20 +6553,46 @@
         "which": "^1.3.0"
       }
     },
-    "node-request-by-swagger": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/node-request-by-swagger/-/node-request-by-swagger-1.1.4.tgz",
-      "integrity": "sha512-hwaTaFPUwNKns5qXwGJpLQM3Z5zRluYeAxpYy1L8fWmWdT/DjLmsnW8/oGlSN8Vo4R28c2znfUoBUiB/RlPptw=="
+    "node-pre-gyp": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
+      "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "needle": "^2.2.1",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4"
+      }
     },
     "noop-logger": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
       "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
     },
+    "nopt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      }
+    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
         "is-builtin-module": "^1.0.0",
@@ -7773,21 +6608,30 @@
         "remove-trailing-separator": "^1.0.1"
       }
     },
+    "npm-bundled": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
+      "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
+      "dev": true,
+      "optional": true
+    },
+    "npm-packlist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.2.0.tgz",
+      "integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1"
+      }
+    },
     "npm-path": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
       "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
       "requires": {
         "which": "^1.2.10"
-      }
-    },
-    "npm-paths": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/npm-paths/-/npm-paths-1.0.0.tgz",
-      "integrity": "sha512-COlxSO5PK9UvZXIa7/sqJDZOlffWFx9+CKJJWkdbhUJMBwcf9sof2jxt4uiVsl+nY3sy0/XFGl4iGr8GoKfiXA==",
-      "requires": {
-        "global-modules": "^1.0.0",
-        "is-windows": "^1.0.1"
       }
     },
     "npm-run": {
@@ -7975,19 +6819,6 @@
         "mimic-fn": "^1.0.0"
       }
     },
-    "ono": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
-      "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
-      "requires": {
-        "format-util": "^1.0.3"
-      }
-    },
-    "open": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
-      "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw="
-    },
     "opn": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
@@ -8027,36 +6858,26 @@
         "wordwrap": "~1.0.0"
       }
     },
-    "ora": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-1.4.0.tgz",
-      "integrity": "sha512-iMK1DOQxzzh2MBlVsU42G80mnrvUhqsMh74phHtDlrcTZPK0pH6o7l7DRshK+0YsxDyEuaOkziVdvM3T0QTzpw==",
-      "requires": {
-        "chalk": "^2.1.0",
-        "cli-cursor": "^2.1.0",
-        "cli-spinners": "^1.0.1",
-        "log-symbols": "^2.1.0"
-      }
-    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
-    "os-locale": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-      "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
-      }
-    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
     },
     "p-defer": {
       "version": "1.0.0",
@@ -8073,27 +6894,6 @@
       "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
     },
-    "p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "requires": {
-        "p-try": "^1.0.0"
-      }
-    },
-    "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "requires": {
-        "p-limit": "^1.1.0"
-      }
-    },
-    "p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-    },
     "package-json": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
@@ -8109,19 +6909,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.3.1.tgz",
       "integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc="
-    },
-    "param-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
-      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-      "requires": {
-        "no-case": "^2.2.0"
-      }
-    },
-    "parse-github-url": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
-      "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw=="
     },
     "parse-glob": {
       "version": "3.0.4",
@@ -8152,19 +6939,6 @@
         }
       }
     },
-    "parse-json": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
-      "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
-      "requires": {
-        "error-ex": "^1.3.1"
-      }
-    },
-    "parse-passwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
-    },
     "parse5": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
@@ -8176,27 +6950,10 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
-    "pascal-case": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
-      "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
-      "requires": {
-        "camel-case": "^3.0.0",
-        "upper-case-first": "^1.1.0"
-      }
-    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
-    },
-    "path-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
-      "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
-      "requires": {
-        "no-case": "^2.2.0"
-      }
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -8234,29 +6991,21 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
-    "path-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-      "requires": {
-        "pify": "^2.0.0"
-      }
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pg": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-7.7.1.tgz",
-      "integrity": "sha512-p3I0mXOmUvCoVlCMFW6iYSrnguPol6q8He15NGgSIdM3sPGjFc+8JGCeKclw8ZR4ETd+Jxy2KNiaPUcocHZeMw==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.8.0.tgz",
+      "integrity": "sha512-yS3C9YD+ft0H7G47uU0eKajgTieggCXdA+Fxhm5G+wionY6kPBa8BEVDwPLMxQvkRkv3/LXiFEqjZm9gfxdW+g==",
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "0.3.1",
         "pg-connection-string": "0.1.3",
         "pg-pool": "^2.0.4",
-        "pg-types": "~1.12.1",
+        "pg-types": "~2.0.0",
         "pgpass": "1.x",
         "semver": "4.3.2"
       },
@@ -8273,17 +7022,23 @@
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
       "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
     },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
     "pg-pool": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.5.tgz",
-      "integrity": "sha512-T4W9qzP2LjItXuXbW6jgAF2AY0jHp6IoTxRhM3GB7yzfBxzDnA3GCm0sAduzmmiCybMqD0+V1HiqIG5X2YWqlQ=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.6.tgz",
+      "integrity": "sha512-hod2zYQxM8Gt482q+qONGTYcg/qVcV32VHVPtktbBJs0us3Dj7xibISw0BAAXVMCzt8A/jhfJvpZaxUlqtqs0g=="
     },
     "pg-types": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
-      "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.0.0.tgz",
+      "integrity": "sha512-THUD7gQll5tys+5eQ8Rvs7DjHiIC3bLqixk3gMN9Hu8UrCBAOjf35FoI39rTGGc3lM2HU/R+Knpxvd11mCwOMA==",
       "requires": {
-        "postgres-array": "~1.0.0",
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
         "postgres-bytea": "~1.0.0",
         "postgres-date": "~1.0.0",
         "postgres-interval": "^1.1.0"
@@ -8296,11 +7051,6 @@
       "requires": {
         "split": "^1.0.0"
       }
-    },
-    "pify": {
-      "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -8403,9 +7153,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postgres-array": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.3.tgz",
-      "integrity": "sha512-5wClXrAP0+78mcsNX3/ithQ5exKvCyK5lr5NEEEeGwwM6NJdQgzIJBVxLvRW+huFpX92F2QnZ5CcokH0VhK2qQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
     },
     "postgres-bytea": {
       "version": "1.0.0",
@@ -8497,13 +7247,13 @@
       }
     },
     "prisma": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-1.23.2.tgz",
-      "integrity": "sha512-2Nn9HzyuM4L9ECUP9nsFFmCx1whS8/+o/2jO/Nm+O4xxKH3A5tjN83tlhj1sT/e+uRcGLorNt9LPukpkRHU+9Q==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-1.24.0.tgz",
+      "integrity": "sha512-+Mel+QJ8+ZTn7CGKrcGmg7Y8Gcue4Ri6A/hNXtxb04B+Njrl0E/Mj5PNgJwV8shjClQ8AAvH6FOqaeKTWnswUg==",
       "requires": {
         "fs-extra": "^7.0.0",
-        "prisma-cli-core": "1.23.2",
-        "prisma-cli-engine": "1.23.2",
+        "prisma-cli-core": "1.24.0",
+        "prisma-cli-engine": "1.24.0",
         "semver": "^5.4.1",
         "source-map-support": "^0.4.18"
       },
@@ -8720,9 +7470,9 @@
       }
     },
     "prisma-cli-core": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/prisma-cli-core/-/prisma-cli-core-1.23.2.tgz",
-      "integrity": "sha512-gaEWXUOJbsAcf2XMbBU59ePxCMG25m1WdTovBmzioGZ+rf8l6id7PfXZmqUZO7cBWbMzFGl4eOUNX5i25O7y2A==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/prisma-cli-core/-/prisma-cli-core-1.24.0.tgz",
+      "integrity": "sha512-P/BK3Vj6mh08D4lYYcMZBool+fRNOpAf/jfDkjwpXWf/VEdy1D/2xrR4MmRJ5rM8QztraHRcWjwv2TYsGc9kFw==",
       "requires": {
         "adm-zip": "^0.4.7",
         "archiver": "^2.0.3",
@@ -8748,11 +7498,11 @@
         "node-forge": "^0.7.1",
         "npm-run": "4.1.2",
         "opn": "^5.1.0",
-        "prisma-client-lib": "1.23.2",
-        "prisma-datamodel": "1.23.2",
-        "prisma-db-introspection": "1.23.2",
-        "prisma-generate-schema": "1.23.2",
-        "prisma-yml": "1.23.2",
+        "prisma-client-lib": "1.24.0",
+        "prisma-datamodel": "1.24.0",
+        "prisma-db-introspection": "1.24.0",
+        "prisma-generate-schema": "1.24.0",
+        "prisma-yml": "1.24.0",
         "scuid": "^1.0.2",
         "sillyname": "^0.1.0",
         "source-map-support": "^0.4.18",
@@ -8819,9 +7569,9 @@
           "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
         },
         "prisma-yml": {
-          "version": "1.23.2",
-          "resolved": "https://registry.npmjs.org/prisma-yml/-/prisma-yml-1.23.2.tgz",
-          "integrity": "sha512-OUiQBYJ0kdC2k+8xHIcJTqcc2JLfsGKcsA0o5xvSz/RYXJwD5uKzPuJBNMCyb+tW6KtcwaP+NWUAG2oiz6DUhQ==",
+          "version": "1.24.0",
+          "resolved": "https://registry.npmjs.org/prisma-yml/-/prisma-yml-1.24.0.tgz",
+          "integrity": "sha512-KgIBnEFSM0htnZd09UquZOxwFqk78eeOXDg8GBiiRqXj5M8PY5o1hj3CYt80vA74OGhm5TWnb68vFzqg52H5VQ==",
           "requires": {
             "ajv": "5",
             "bluebird": "^3.5.1",
@@ -8865,9 +7615,9 @@
           },
           "dependencies": {
             "ajv": {
-              "version": "6.6.2",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
-              "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
+              "version": "6.7.0",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
+              "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
               "requires": {
                 "fast-deep-equal": "^2.0.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -8890,9 +7640,9 @@
       }
     },
     "prisma-cli-engine": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/prisma-cli-engine/-/prisma-cli-engine-1.23.2.tgz",
-      "integrity": "sha512-L/8/rkF+bKBKs6kzRQ34xF+9UDWAAlFYrDVTBAUAJWP2xrYAmKhIlQyth4l0/xcPWIPbnVSGXjhtjftxWDqDXQ==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/prisma-cli-engine/-/prisma-cli-engine-1.24.0.tgz",
+      "integrity": "sha512-j+OzUy84P4SC6b3D6SIsyhk6EzGpJ4bPnpqXtisqpHrUXt+hccKiOBGUoLNYEO4t/nfGmg0F6oluqAxsYh09tQ==",
       "requires": {
         "@heroku/linewrap": "^1.0.0",
         "ansi-escapes": "^3.0.0",
@@ -8927,7 +7677,7 @@
         "mkdirp": "^0.5.1",
         "opn": "^5.1.0",
         "prisma-json-schema": "0.1.3",
-        "prisma-yml": "1.23.2",
+        "prisma-yml": "1.24.0",
         "raven": "2.6.4",
         "rwlockfile": "^1.4.8",
         "scuid": "^1.0.2",
@@ -9007,9 +7757,9 @@
           }
         },
         "p-limit": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+          "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -9028,9 +7778,9 @@
           "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
         },
         "prisma-yml": {
-          "version": "1.23.2",
-          "resolved": "https://registry.npmjs.org/prisma-yml/-/prisma-yml-1.23.2.tgz",
-          "integrity": "sha512-OUiQBYJ0kdC2k+8xHIcJTqcc2JLfsGKcsA0o5xvSz/RYXJwD5uKzPuJBNMCyb+tW6KtcwaP+NWUAG2oiz6DUhQ==",
+          "version": "1.24.0",
+          "resolved": "https://registry.npmjs.org/prisma-yml/-/prisma-yml-1.24.0.tgz",
+          "integrity": "sha512-KgIBnEFSM0htnZd09UquZOxwFqk78eeOXDg8GBiiRqXj5M8PY5o1hj3CYt80vA74OGhm5TWnb68vFzqg52H5VQ==",
           "requires": {
             "ajv": "5",
             "bluebird": "^3.5.1",
@@ -9063,9 +7813,9 @@
       }
     },
     "prisma-client-lib": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/prisma-client-lib/-/prisma-client-lib-1.23.2.tgz",
-      "integrity": "sha512-a926nHwe1lavB4erwHcvksy0XGoFsMR158vm9oII9MauxW9v2hRgu4sVDcR9wcGHg42eaJPvT6hjloF0GITLiQ==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/prisma-client-lib/-/prisma-client-lib-1.24.0.tgz",
+      "integrity": "sha512-IK8y4iwCpIhuf4uhoVgJ3ptbx6rk+qMTi6gBeI5tuxRSmJpMWU4r0Cro6t3V34oxGSaT9z2h+tx9JsXuMmJoWA==",
       "requires": {
         "@types/node": "^10.12.0",
         "@types/prettier": "^1.13.2",
@@ -9076,8 +7826,8 @@
         "jsonwebtoken": "^8.3.0",
         "lodash.flatten": "^4.4.0",
         "prettier": "^1.14.3",
-        "prisma-datamodel": "1.23.2",
-        "prisma-generate-schema": "1.23.2",
+        "prisma-datamodel": "1.24.0",
+        "prisma-generate-schema": "1.24.0",
         "subscriptions-transport-ws": "^0.9.15",
         "uppercamelcase": "^3.0.0",
         "ws": "^6.1.0",
@@ -9085,9 +7835,9 @@
       }
     },
     "prisma-datamodel": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/prisma-datamodel/-/prisma-datamodel-1.23.2.tgz",
-      "integrity": "sha512-q3c5+EcO4/t7bFnDTc4WBPjocJnE/kmvNHcvHQWyd2CMjbkFWk3OA3viKss+J6//bsb10zRsi4Vu4CZdwHmIgw==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/prisma-datamodel/-/prisma-datamodel-1.24.0.tgz",
+      "integrity": "sha512-pJsJ3lVpLVVx9GXS+3Mm+JhKY7qvO57hgYzEGIgkqLUEkoCmZtaV6/Re97WbY8vxvjKlEFGEAfPch1ZiKBvDLw==",
       "requires": {
         "graphql": "^14.0.2",
         "pluralize": "^7.0.0",
@@ -9095,9 +7845,9 @@
       }
     },
     "prisma-db-introspection": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/prisma-db-introspection/-/prisma-db-introspection-1.23.2.tgz",
-      "integrity": "sha512-GLO3FwDNupVidw6cwVa4eINfzEKdTDaJVJS0Su1XXwd1Si1luZ1juix30Iz9SHXu15dcIWVx+vUwAWg4VdS0VA==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/prisma-db-introspection/-/prisma-db-introspection-1.24.0.tgz",
+      "integrity": "sha512-e9N1MBFwKLT+cG1yVF4N3MYQhu+Kl9zUgXHJhNmW77pLS8xepeE2DQLGTk1Pb3Xw6YjDuLUsh2ep34N8vBcdjQ==",
       "requires": {
         "@types/mongodb": "^3.1.14",
         "graphql-request": "^1.5.0",
@@ -9105,8 +7855,8 @@
         "mongodb": "^3.1.10",
         "pg": "^7.4.1",
         "pluralize": "^7.0.0",
-        "prisma-datamodel": "1.23.2",
-        "prisma-yml": "1.23.2",
+        "prisma-datamodel": "1.24.0",
+        "prisma-yml": "1.24.0",
         "scuid": "^1.0.2",
         "uppercamelcase": "^3.0.0"
       },
@@ -9156,9 +7906,9 @@
           "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
         },
         "prisma-yml": {
-          "version": "1.23.2",
-          "resolved": "https://registry.npmjs.org/prisma-yml/-/prisma-yml-1.23.2.tgz",
-          "integrity": "sha512-OUiQBYJ0kdC2k+8xHIcJTqcc2JLfsGKcsA0o5xvSz/RYXJwD5uKzPuJBNMCyb+tW6KtcwaP+NWUAG2oiz6DUhQ==",
+          "version": "1.24.0",
+          "resolved": "https://registry.npmjs.org/prisma-yml/-/prisma-yml-1.24.0.tgz",
+          "integrity": "sha512-KgIBnEFSM0htnZd09UquZOxwFqk78eeOXDg8GBiiRqXj5M8PY5o1hj3CYt80vA74OGhm5TWnb68vFzqg52H5VQ==",
           "requires": {
             "ajv": "5",
             "bluebird": "^3.5.1",
@@ -9183,14 +7933,14 @@
       }
     },
     "prisma-generate-schema": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/prisma-generate-schema/-/prisma-generate-schema-1.23.2.tgz",
-      "integrity": "sha512-d+x3v1w6BzM46wO0ExfXzmXnlX7fo/W46ZUym5EasgeVLnGDg2HIzHRIxQ4pfq4xSx8yZIz69VxaXmqaU/EJmQ==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/prisma-generate-schema/-/prisma-generate-schema-1.24.0.tgz",
+      "integrity": "sha512-NhWhCn7+NUMIbVHkJ1LzZPGxAH9T3VKXzUV+wRzrszUiVc6/KZc3ENMxadDNN/3mHYuB8yBccM7//XQ1pBnw8g==",
       "requires": {
         "graphql": "^14.0.2",
         "pluralize": "^7.0.0",
         "popsicle": "10",
-        "prisma-datamodel": "1.23.2"
+        "prisma-datamodel": "1.24.0"
       }
     },
     "prisma-json-schema": {
@@ -9438,25 +8188,6 @@
         }
       }
     },
-    "read-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-      "requires": {
-        "load-json-file": "^2.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^2.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-      "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^2.0.0"
-      }
-    },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -9498,7 +8229,8 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
     "regex-cache": {
       "version": "0.4.4",
@@ -9631,11 +8363,6 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
-    "require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
-    },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
@@ -9685,15 +8412,6 @@
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
           "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
         }
-      }
-    },
-    "resolve-dir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-      "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
       }
     },
     "resolve-from": {
@@ -9818,8 +8536,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "scuid": {
       "version": "1.1.0",
@@ -9872,15 +8589,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
-      }
-    },
-    "sentence-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
-      "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
-      "requires": {
-        "no-case": "^2.2.0",
-        "upper-case-first": "^1.1.2"
       }
     },
     "serialize-error": {
@@ -10045,14 +8753,6 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
-    "snake-case": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
-      "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
-      "requires": {
-        "no-case": "^2.2.0"
-      }
-    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -10206,6 +8906,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -10214,12 +8915,14 @@
     "spdx-exceptions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -10228,7 +8931,8 @@
     "spdx-license-ids": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg=="
+      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+      "dev": true
     },
     "split": {
       "version": "1.0.1",
@@ -10362,7 +9066,8 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -10404,13 +9109,20 @@
         "has-flag": "^3.0.0"
       }
     },
-    "swap-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
-      "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
+    "supports-hyperlinks": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz",
+      "integrity": "sha512-HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==",
       "requires": {
-        "lower-case": "^1.1.1",
-        "upper-case": "^1.1.1"
+        "has-flag": "^2.0.0",
+        "supports-color": "^5.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        }
       }
     },
     "symbol-observable": {
@@ -10727,30 +9439,12 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
-    "title-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
-      "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
-      "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.0.3"
-      }
-    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
         "os-tmpdir": "~1.0.2"
-      }
-    },
-    "tmp-graphql-config-extension-openapi": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/tmp-graphql-config-extension-openapi/-/tmp-graphql-config-extension-openapi-1.0.7.tgz",
-      "integrity": "sha512-NQPUaywaVC2hzWkBBsTX3sV2XfxU0mc409rJyrA7iCu5DSTjMLUqI+U4KJVSy/Ltp0zgbWMWua471R7zMql9Pw==",
-      "requires": {
-        "@kbrandwijk/swagger-to-graphql": "2.4.3",
-        "graphql-config": "2.2.1"
       }
     },
     "tmpl": {
@@ -10767,7 +9461,8 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -10812,6 +9507,21 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
+    "topo": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+      "requires": {
+        "hoek": "6.x.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
+          "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
+        }
+      }
+    },
     "tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -10837,11 +9547,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "traverse-chain": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/traverse-chain/-/traverse-chain-0.1.0.tgz",
-      "integrity": "sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE="
-    },
     "treeify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
@@ -10850,7 +9555,8 @@
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
     },
     "ts-jest": {
       "version": "23.10.5",
@@ -11111,14 +9817,6 @@
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
-    "upper-case-first": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
-      "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
-      "requires": {
-        "upper-case": "^1.1.1"
-      }
-    },
     "uppercamelcase": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/uppercamelcase/-/uppercamelcase-3.0.0.tgz",
@@ -11151,14 +9849,6 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "requires": {
         "prepend-http": "^1.0.1"
-      }
-    },
-    "url-regex": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz",
-      "integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
-      "requires": {
-        "ip-regex": "^1.0.1"
       }
     },
     "use": {
@@ -11194,15 +9884,11 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "validator": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-10.9.0.tgz",
-      "integrity": "sha512-hZJcZSWz9poXBlAkjjcsNAdrZ6JbjD3kWlNjq/+vE7RLLS/+8PAj3qVVwrwsOz/WL8jPmZ1hYkRvtlUeZAm4ug=="
     },
     "vary": {
       "version": "1.1.2",
@@ -11253,14 +9939,6 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
-      }
-    },
-    "wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-      "requires": {
-        "defaults": "^1.0.3"
       }
     },
     "webidl-conversions": {
@@ -11423,6 +10101,22 @@
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
     },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      },
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "9.0.7",
+          "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+        }
+      }
+    },
     "xmlbuilder": {
       "version": "8.2.2",
       "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
@@ -11449,66 +10143,10 @@
       "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.40.tgz",
       "integrity": "sha1-CFNtTnPTIrHJziB6uN1w4E0grm4="
     },
-    "yargs": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
-      "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
-      "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^1.1.1",
-        "find-up": "^2.1.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^2.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^9.0.2"
-      },
-      "dependencies": {
-        "yargs-parser": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-          "requires": {
-            "camelcase": "^4.1.0"
-          }
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-      "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
-      "requires": {
-        "camelcase": "^4.1.0"
-      }
-    },
     "yn": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
       "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
-    },
-    "z-schema": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.24.2.tgz",
-      "integrity": "sha512-Zb2YLJ9g72MexBXKPRzoypd4OZfVkFghdy10eVbcMNLl9YQsPXtyMpiK7a3sG7IIERg1lEDjEMrG9Km9DPbWLw==",
-      "requires": {
-        "commander": "^2.7.1",
-        "core-js": "^2.5.7",
-        "lodash.get": "^4.0.0",
-        "lodash.isequal": "^4.0.0",
-        "validator": "^10.0.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.1.tgz",
-          "integrity": "sha512-L72mmmEayPJBejKIWe2pYtGis5r0tQ5NaJekdhyXgeMQTpJoBsH0NL4ElY2LfSoV15xeQWKQ+XTTOZdyero5Xg=="
-        }
-      }
     },
     "zen-observable": {
       "version": "0.8.11",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "license": "AGPL-3.0-or-later",
   "dependencies": {
     "@okgrow/graphql-scalars": "^0.4.2",
+    "amqplib": "^0.5.3",
     "apollo-server": "^2.3.1",
     "cluster": "^0.7.7",
     "codacy-coverage": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "node src/cluster.js",
-    "dev": "node src/index.js",
+    "dev": "PRISMA_API_ENDPOINT=localhost  yarn prisma deploy && NODE_ENV=development node src/index.js",
     "eslint": "eslint src/",
     "test": "PRISMA_API_ENDPOINT=localhost yarn prisma deploy && jest --runInBand --coverage"
   },

--- a/src/Service_Mesh/connector.js
+++ b/src/Service_Mesh/connector.js
@@ -5,64 +5,77 @@ const { msgHandler } = require("./handler");
 
 // object to hold connection
 var amqpConn = null;
-// array of keys
-const bindingKeys = ["user.new"];
 
-// TODO: Create an arry of exchanges and associated keys to be passed into connection manager.
+const exchangesAndBindings = {
+    account: ["user.new", "user.modification", "user.delete"],
+    notification: ["app.viewed"],
+};
 
-function closeOnErr(err) {
+function closeOnErr(err, ch) {
     if (!err) {
         return false;
     }
     // eslint-disable-next-line no-console
     console.error("[SMQ] error", err);
-    amqpConn.close();
+    ch.close();
     return true;
   }
 
-function listenMessageQueue(){
+function listenMessageQueue(exchange){
+
+    var retryDelay = 5000;
+
     amqpConn.createChannel(function(err, ch) {
 
-        if (closeOnErr(err)) {
-            return;
-        }
         ch.on("error", function(err) {
-        // eslint-disable-next-line no-console
-        console.error("[SMQ] channel error", err.message);
+            // eslint-disable-next-line no-console
+            console.error("[SMQ] channel error", err.message);
         });
         ch.on("close", function() {
-        // eslint-disable-next-line no-console
-        console.log("[SMQ] channel closed");
-        });
-        
-        // Replace with a funtion to handle multiple exchanges and keys
-        var ex = "account";
-   
-        ch.assertQueue("profile", {durable: true}, function(err, q) {
-            if (closeOnErr(err)) {
-                return;
-            }
-    
-            bindingKeys.forEach(function(key) {
-            ch.bindQueue(q.queue, ex, key);
-            });
-    
-            ch.consume(q.queue, function(msg) {
+            // eslint-disable-next-line no-console
+            console.log("[SMQ] channel '" + exchange + "' closed");
+            setTimeout(function() {
+                listenMessageQueue(exchange); 
+            },retryDelay);
+        }); 
+        ch.checkExchange(exchange, function(err, ok){
+            if (ok) {
+                console.log("The world is beautiful - '" + exchange + "' exists");
 
-                msgHandler(msg, function(ok) {
-                    try {
-                      if (ok) {
-                        ch.ack(msg);
-                      } else {
-                        ch.reject(msg, true);
-                      }                    
-                    } catch (e) {
-                      closeOnErr(e);
+                ch.assertQueue("profile", {durable: true}, function(err, q) {
+                    if (closeOnErr(err, ch)) {
+                        return;
                     }
+        
+                    exchangesAndBindings[exchange].forEach(function(key) {
+                        ch.bindQueue(q.queue, exchange, key);
+                    });
+        
+                    ch.prefetch(1);
+                    ch.consume(q.queue, function(msg) {
+        
+                        msgHandler(msg, function(ok) {
+                            try {
+                                if (ok) {
+                                    ch.ack(msg);
+                                } else {
+                                    ch.reject(msg, true);
+                                }                    
+                            } catch (e) {
+                                closeOnErr(e);
+                            }
+                        });
+        
+                    }, {noAck: false}); 
                 });
-
-            }, {noAck: false}); 
-        });
+            } else {
+                console.log("Exchange '" + exchange + "' does not exists");
+                retryDelay = retryDelay * 2;
+                if (retryDelay >= 3601000){
+                    retryDelay = 3600000;
+                }
+            }
+        });                 
     });
 }
 
@@ -74,30 +87,31 @@ function connectMessageQueue(){
             // eslint-disable-next-line no-console
             console.error("[SMQ]", err.message);
             return setTimeout(connectMessageQueue, 5000);
-          }
-          conn.on("error", function(err) {
+        }
+        conn.on("error", function(err) {
             if (err.message !== "Connection closing") {
                 // eslint-disable-next-line no-console
                 console.error("[SMQ conn error", err.message);
             }
-          });
-          conn.on("close", function() {
+        });
+        conn.on("close", function() {
               // eslint-disable-next-line no-console
                 console.error("[SMQ] reconnecting");
                 return setTimeout(connectMessageQueue, 5000);
-          });
+        });
 
-          // eslint-disable-next-line no-console      
-          console.log("[SMQ] connected");
-          amqpConn = conn;
-      
-          listenMessageQueue();
+        // eslint-disable-next-line no-console      
+        console.log("[SMQ] connected");
+        amqpConn = conn;
 
-
+        for (let exchange in exchangesAndBindings){
+            if (exchangesAndBindings.hasOwnProperty(exchange)){
+                listenMessageQueue(exchange);
+            }  
+        }
     });
 }
 
 module.exports = {
     connectMessageQueue,
 };
-

--- a/src/Service_Mesh/connector.js
+++ b/src/Service_Mesh/connector.js
@@ -1,0 +1,98 @@
+require("dotenv").config();
+const config = require("../config");
+const amqp = require("amqplib/callback_api");
+const { msgHandler } = require("./handler");
+
+// object to hold connection
+var amqpConn = null;
+// array of keys
+const bindingKeys = ["user.new"];
+
+// TODO: Create an arry of exchanges and associated keys to be passed into connection manager.
+
+function closeOnErr(err) {
+    if (!err) {
+        return false;
+    }
+    console.error("[SMQ] error", err);
+    amqpConn.close();
+    return true;
+  }
+
+function listenMessageQueue(){
+    amqpConn.createChannel(function(err, ch) {
+
+        if (closeOnErr(err)) {
+            return;
+        }
+        ch.on("error", function(err) {
+        console.error("[SMQ] channel error", err.message);
+        });
+        ch.on("close", function() {
+        console.log("[SMQ] channel closed");
+        });
+        
+        // Replace with a funtion to handle multiple exchanges and keys
+        var ex = "account";
+   
+        ch.assertQueue("profile", {durable: true}, function(err, q) {
+            if (closeOnErr(err)) {
+                return;
+            }
+    
+            bindingKeys.forEach(function(key) {
+            ch.bindQueue(q.queue, ex, key);
+            });
+    
+            ch.consume(q.queue, function(msg) {
+
+                msgHandler(msg, function(ok) {
+                    try {
+                      if (ok) {
+                        ch.ack(msg);
+                      } else {
+                        ch.reject(msg, true);
+                      }                    
+                    } catch (e) {
+                      closeOnErr(e);
+                    }
+                });
+
+            }, {noAck: false}); 
+
+            console.log(" [*] Waiting for logs. To exit press CTRL+C");
+        });
+    });
+}
+
+// if the connection is closed or fails to be established at all, we will reconnect
+function connectMessageQueue(){
+  
+    amqp.connect("amqp://" + process.env.MQ_USER + ":" + process.env.MQ_PASS + "@" + config.rabbitMQ.host +"?heartbeat=60", function(err, conn) {
+        if (err) {
+            console.error("[SMQ]", err.message);
+            return setTimeout(connectMessageQueue, 5000);
+          }
+          conn.on("error", function(err) {
+            if (err.message !== "Connection closing") {
+              console.error("[SMQ conn error", err.message);
+            }
+          });
+          conn.on("close", function() {
+            console.error("[SMQ] reconnecting");
+            return setTimeout(connectMessageQueue, 5000);
+          });
+      
+          console.log("[SMQ] connected");
+          amqpConn = conn;
+      
+          listenMessageQueue();
+
+
+    });
+}
+
+module.exports = {
+    connectMessageQueue,
+};
+

--- a/src/Service_Mesh/connector.js
+++ b/src/Service_Mesh/connector.js
@@ -14,6 +14,7 @@ function closeOnErr(err) {
     if (!err) {
         return false;
     }
+    // eslint-disable-next-line no-console
     console.error("[SMQ] error", err);
     amqpConn.close();
     return true;
@@ -26,9 +27,11 @@ function listenMessageQueue(){
             return;
         }
         ch.on("error", function(err) {
+        // eslint-disable-next-line no-console
         console.error("[SMQ] channel error", err.message);
         });
         ch.on("close", function() {
+        // eslint-disable-next-line no-console
         console.log("[SMQ] channel closed");
         });
         
@@ -59,8 +62,6 @@ function listenMessageQueue(){
                 });
 
             }, {noAck: false}); 
-
-            console.log(" [*] Waiting for logs. To exit press CTRL+C");
         });
     });
 }
@@ -70,19 +71,23 @@ function connectMessageQueue(){
   
     amqp.connect("amqp://" + process.env.MQ_USER + ":" + process.env.MQ_PASS + "@" + config.rabbitMQ.host +"?heartbeat=60", function(err, conn) {
         if (err) {
+            // eslint-disable-next-line no-console
             console.error("[SMQ]", err.message);
             return setTimeout(connectMessageQueue, 5000);
           }
           conn.on("error", function(err) {
             if (err.message !== "Connection closing") {
-              console.error("[SMQ conn error", err.message);
+                // eslint-disable-next-line no-console
+                console.error("[SMQ conn error", err.message);
             }
           });
           conn.on("close", function() {
-            console.error("[SMQ] reconnecting");
-            return setTimeout(connectMessageQueue, 5000);
+              // eslint-disable-next-line no-console
+                console.error("[SMQ] reconnecting");
+                return setTimeout(connectMessageQueue, 5000);
           });
-      
+
+          // eslint-disable-next-line no-console      
           console.log("[SMQ] connected");
           amqpConn = conn;
       

--- a/src/Service_Mesh/handler.js
+++ b/src/Service_Mesh/handler.js
@@ -1,8 +1,11 @@
 // Handler for messages from different exchanges and keys
 
-function msgHandler(msg) {
+function msgHandler(msg, cb) {
     console.log(" [x] %s:'%s'", msg.fields.routingKey, msg.content.toString());
-    return true;
+    setTimeout(function(){
+        console.log("Done [X]");
+        cb(true);
+    },3000);
 }
 
 module.exports = {

--- a/src/Service_Mesh/handler.js
+++ b/src/Service_Mesh/handler.js
@@ -1,0 +1,10 @@
+// Handler for messages from different exchanges and keys
+
+function msgHandler(msg) {
+    console.log(" [x] %s:'%s'", msg.fields.routingKey, msg.content.toString());
+    return true;
+}
+
+module.exports = {
+    msgHandler
+};

--- a/src/Service_Mesh/handler.js
+++ b/src/Service_Mesh/handler.js
@@ -1,11 +1,70 @@
 // Handler for messages from different exchanges and keys
+const { Prisma } = require("prisma-binding");
+const { createProfile } = require("../resolvers/Mutations");
+const {GraphQLError} = require("graphql");
+const { publishMessageQueue } = require("./publisher_connector");
+const config = require("../config");
 
-function msgHandler(msg, cb) {
-    console.log(" [x] %s:'%s'", msg.fields.routingKey, msg.content.toString());
-    setTimeout(function(){
-        console.log("Done [X]");
-        cb(true);
-    },3000);
+const context = {
+    prisma: new Prisma({
+        typeDefs: "./src/generated/prisma.graphql",
+        endpoint: "http://"+config.prisma.host+":4466/profile/",
+        debug: config.prisma.debug,
+      }),
+};
+
+async function msgHandler(msg, success) {
+    const messageBody = JSON.parse(msg.content.toString());
+    switch (msg.fields.routingKey){
+        case "user.new":
+            var args = {
+                gcID: messageBody.gcID,
+                name: messageBody.name,
+                email: messageBody.name
+            };
+            try {
+                await createProfile(null, args, context, "{gcID, name, email}");
+                success(true);
+            } catch(err){
+                if (err instanceof GraphQLError){
+                    let rejectMsg = {
+                        args,
+                        error: err
+                    };
+                    try{
+                        await publishMessageQueue("errors", "profile.creation", rejectMsg);
+                    } catch(err){
+                        // eslint-disable-next-line no-console
+                        console.error(err);
+                    }
+                    // The error has been handled and no longer need to be in queue
+                    success(true);
+
+
+                } else{
+                    // If it's not a GraphQL Error then requeue it.
+                    success(false);
+                }
+            }
+            break;
+        default:
+            let rejectMsg = {
+                msg: messageBody,
+                key: msg.fields.routingKey,
+                error: "No handler method available"
+            };
+            try {
+                await publishMessageQueue("errors", "profile.noHandler", rejectMsg);
+            } catch(err){
+                // Could not forward error - will need to cache these
+                // eslint-disable-next-line no-console
+                console.error(err);
+            }
+            // eslint-disable-next-line no-console
+            console.error("No handler method available - Default Policy : Drop to error");
+            success(true);
+            break;        
+    }
 }
 
 module.exports = {

--- a/src/Service_Mesh/listener_connector.js
+++ b/src/Service_Mesh/listener_connector.js
@@ -3,73 +3,77 @@ const config = require("../config");
 const amqp = require("amqplib/callback_api");
 const { msgHandler } = require("./handler");
 
-// object to hold connection
-var amqpConn = null;
+// object to hold connection for listeners
+var listenerConnection = null;
+var listenQueueOptions = {
+    durable: true,
+};
 
-const exchangesAndBindings = {
+const listenExchangesAndBindings = {
     account: ["user.new", "user.modification", "user.delete"],
     notification: ["app.viewed"],
 };
 
-function closeOnErr(err, ch) {
+function closeOnErr(err, listenerChannel) {
     if (!err) {
         return false;
     }
     // eslint-disable-next-line no-console
     console.error("[SMQ] error", err);
-    ch.close();
+    listenerChannel.close();
     return true;
-  }
+}
 
+// Create channel per exchange to listen to queue and monitor connection status.  If it closes try to reconnect.
 function listenMessageQueue(exchange){
 
     var retryDelay = 5000;
 
-    amqpConn.createChannel(function(err, ch) {
+    listenerConnection.createChannel(function(err, listenerChannel) {
 
-        ch.on("error", function(err) {
+        listenerChannel.on("error", function(err) {
             // eslint-disable-next-line no-console
             console.error("[SMQ] channel error", err.message);
         });
-        ch.on("close", function() {
+        listenerChannel.on("close", function() {
             // eslint-disable-next-line no-console
-            console.log("[SMQ] channel '" + exchange + "' closed");
+            console.info("[SMQ] channel '" + exchange + "' closed");
             setTimeout(function() {
                 listenMessageQueue(exchange); 
             },retryDelay);
         }); 
-        ch.checkExchange(exchange, function(err, ok){
+        listenerChannel.checkExchange(exchange, function(err, ok){
             if (ok) {
-                console.log("The world is beautiful - '" + exchange + "' exists");
-
-                ch.assertQueue("profile", {durable: true}, function(err, q) {
-                    if (closeOnErr(err, ch)) {
+                listenerChannel.assertQueue("profile", listenQueueOptions, function(err, q) {
+                    if (closeOnErr(err, listenerChannel)) {
                         return;
                     }
         
-                    exchangesAndBindings[exchange].forEach(function(key) {
-                        ch.bindQueue(q.queue, exchange, key);
+                    listenExchangesAndBindings[exchange].forEach(function(key) {
+                        listenerChannel.bindQueue(q.queue, exchange, key);
                     });
         
-                    ch.prefetch(1);
-                    ch.consume(q.queue, function(msg) {
+                    listenerChannel.prefetch(1);
+                    listenerChannel.consume(q.queue, function(msg) {
         
-                        msgHandler(msg, function(ok) {
+                        msgHandler(msg, function(success) {
                             try {
-                                if (ok) {
-                                    ch.ack(msg);
+                                if (success){
+                                    // Acknowledge processing and remove from queue
+                                    listenerChannel.ack(msg);
                                 } else {
-                                    ch.reject(msg, true);
-                                }                    
-                            } catch (e) {
-                                closeOnErr(e);
+                                    // Reject processing and return to queue
+                                    listenerChannel.nack(msg);
+                                }
+                            } catch (err) {
+                                closeOnErr(err);
                             }
                         });
         
                     }, {noAck: false}); 
                 });
             } else {
-                console.log("Exchange '" + exchange + "' does not exists");
+                console.warn("Exchange '" + exchange + "' does not exists");
                 retryDelay = retryDelay * 2;
                 if (retryDelay >= 3601000){
                     retryDelay = 3600000;
@@ -80,13 +84,13 @@ function listenMessageQueue(exchange){
 }
 
 // if the connection is closed or fails to be established at all, we will reconnect
-function connectMessageQueue(){
+function connectMessageQueueListener(){
   
     amqp.connect("amqp://" + process.env.MQ_USER + ":" + process.env.MQ_PASS + "@" + config.rabbitMQ.host +"?heartbeat=60", function(err, conn) {
         if (err) {
             // eslint-disable-next-line no-console
             console.error("[SMQ]", err.message);
-            return setTimeout(connectMessageQueue, 5000);
+            return setTimeout(connectMessageQueueListener, 5000);
         }
         conn.on("error", function(err) {
             if (err.message !== "Connection closing") {
@@ -97,15 +101,15 @@ function connectMessageQueue(){
         conn.on("close", function() {
               // eslint-disable-next-line no-console
                 console.error("[SMQ] reconnecting");
-                return setTimeout(connectMessageQueue, 5000);
+                return setTimeout(connectMessageQueueListener, 5000);
         });
 
         // eslint-disable-next-line no-console      
-        console.log("[SMQ] connected");
-        amqpConn = conn;
+        console.info("[SMQ] connected");
+        listenerConnection = conn;
 
-        for (let exchange in exchangesAndBindings){
-            if (exchangesAndBindings.hasOwnProperty(exchange)){
+        for (let exchange in listenExchangesAndBindings){
+            if (listenExchangesAndBindings.hasOwnProperty(exchange)){
                 listenMessageQueue(exchange);
             }  
         }
@@ -113,5 +117,5 @@ function connectMessageQueue(){
 }
 
 module.exports = {
-    connectMessageQueue,
+    connectMessageQueueListener,
 };

--- a/src/Service_Mesh/listener_connector.js
+++ b/src/Service_Mesh/listener_connector.js
@@ -73,6 +73,7 @@ function listenMessageQueue(exchange){
                     }, {noAck: false}); 
                 });
             } else {
+                // eslint-disable-next-line no-console
                 console.warn("Exchange '" + exchange + "' does not exists");
                 retryDelay = retryDelay * 2;
                 if (retryDelay >= 3601000){

--- a/src/Service_Mesh/publisher_connector.js
+++ b/src/Service_Mesh/publisher_connector.js
@@ -1,0 +1,67 @@
+require("dotenv").config();
+const config = require("../config");
+const amqp = require("amqplib/callback_api");
+
+// object to hold connection for publisher
+var publisherConnection = null;
+var publishChannel = null;
+
+async function publishMessageQueue(exchange, key, rejectMsg){
+
+    var retryDelay = 5000;
+
+    if (publishChannel == null){
+        publishChannel = await publisherConnection.createChannel();
+
+        publishChannel.on("error", function(err) {
+            // eslint-disable-next-line no-console
+            console.error("[SMQ] channel error", err.message);
+        });
+        publishChannel.on("close", function() {
+            // eslint-disable-next-line no-console
+            console.info("[SMQ] channel '" + exchange + "' closed");
+            setTimeout(function() {
+                publishMessageQueue(exchange, key); 
+            },retryDelay);
+        }); 
+    }
+    try {
+        await publishChannel.publish(exchange, key, new Buffer(JSON.stringify(rejectMsg), {persistent:true}));
+    } catch(err){
+        // eslint-disable-next-line no-console
+        console.error("[SMQ] error", err);
+        publishChannel.close();
+    }
+}
+
+// if the connection is closed or fails to be established at all, we will reconnect
+function connectMessageQueuePublisher(){
+  
+    amqp.connect("amqp://" + process.env.MQ_USER + ":" + process.env.MQ_PASS + "@" + config.rabbitMQ.host +"?heartbeat=60", function(err, conn) {
+        if (err) {
+            // eslint-disable-next-line no-console
+            console.error("[SMQ]", err.message);
+            return setTimeout(connectMessageQueuePublisher, 5000);
+        }
+        conn.on("error", function(err) {
+            if (err.message !== "Connection closing") {
+                // eslint-disable-next-line no-console
+                console.error("[SMQ conn error", err.message);
+            }
+        });
+        conn.on("close", function() {
+              // eslint-disable-next-line no-console
+                console.error("[SMQ] reconnecting");
+                return setTimeout(connectMessageQueuePublisher, 5000);
+        });
+
+        // eslint-disable-next-line no-console      
+        console.info("[SMQ] connected");
+        publisherConnection = conn;
+    });
+}
+
+module.exports = {
+    connectMessageQueuePublisher,
+    publishMessageQueue
+};

--- a/src/cluster.js
+++ b/src/cluster.js
@@ -7,7 +7,7 @@ if (config.app.multicore){
     const cpus = os.cpus().length;
 
     // eslint-disable-next-line no-console
-    console.log(`Forking for ${cpus} CPUs`);
+    console.info(`Forking for ${cpus} CPUs`);
     for (let i = 0; i<cpus; i++) {
       cluster.fork();
     }

--- a/src/config.js
+++ b/src/config.js
@@ -15,6 +15,9 @@ const development = {
    url:"http://localhost:8007/backend.php",
    format:"jpeg",
    size:300
+ },
+ rabbitMQ:{
+   host:"localhost"
  }
 };
 
@@ -31,6 +34,9 @@ const production = {
   url:"http://image/backend.php",
   format:"jpeg",
   size:300
+},
+rabbitMQ:{
+  host:"mq.gccollab.ca"
 }
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,9 @@ const Mutation = require("./resolvers/Mutations");
 const {PhoneNumber} = require("./resolvers/Scalars");
 const config = require("./config");
 const fs = require("fs");
-const serviceListener = require("./Service_Mesh/connector");
+const { connectMessageQueueListener } = require("./Service_Mesh/listener_connector");
+const { connectMessageQueuePublisher } = require("./Service_Mesh/publisher_connector");
+
 
 const resolvers = {
   Query,
@@ -42,8 +44,9 @@ const server = new ApolloServer({
 
 server.listen().then(({ url }) => { 
   // eslint-disable-next-line no-console
-  console.log(`🚀 GraphQL Server ready at ${url}`);
+  console.info(`🚀 GraphQL Server ready at ${url}`);
 });
 
 // Lauch process to listen to service message queue
-serviceListener.connectMessageQueue();
+connectMessageQueueListener();
+connectMessageQueuePublisher();

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ const Mutation = require("./resolvers/Mutations");
 const {PhoneNumber} = require("./resolvers/Scalars");
 const config = require("./config");
 const fs = require("fs");
+const serviceListener = require("./Service_Mesh/connector");
 
 const resolvers = {
   Query,
@@ -43,3 +44,6 @@ server.listen().then(({ url }) => {
   // eslint-disable-next-line no-console
   console.log(`🚀 GraphQL Server ready at ${url}`);
 });
+
+// Lauch process to listen to service message queue
+serviceListener.connectMessageQueue();


### PR DESCRIPTION
# Description
This pull request enables Profile as a Service to communicate with a RabbitMQ server to actively listen for events published to the 'account' exchange as well as publish any errors to the 'errors' exchange.

# Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

All tests included an instance of a configured and hosted RabbitMQ server.

- [x] PaaS was able to successfully listen and process a message for 'user.new'.  The message as received and the profile was created.
- [x] Paas was able to successfully listen and process a message for a 'user.new'.  When the error was thrown by Prisma that the profile already existed Paas was able to successfully publish to the 'error' exchange on RabbitMQ with the key 'profile.creation'.
- [x] Pass was able to successfully listen and process a message for an unknown event.  When PasS was misconfigured to receive messages that no event handler was created for PaaS was able to identify and handle those errors by publishing them to the 'errors' exchange with key 'profile.noHandler.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
