### PR TITLE
Make introspection async and avoid race conditions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,19 +28,19 @@ const schema = makeExecutableSchema({
   }
 });
 
-
 const server = new ApolloServer({
   schema,
-  context: (req) => ({
-    ...req,
+  context: async (req) => ({
+    ...req,    
     prisma: new Prisma({
       typeDefs: "./src/generated/prisma.graphql",
       endpoint: "http://"+config.prisma.host+":4466/profile/",
       debug: config.prisma.debug,
     }),
-    token: introspect.verifyToken(req),
+    token: await introspect.verifyToken(req),
   }),
 });
+
 
 
 server.listen().then(({ url }) => {

--- a/src/introspection.js
+++ b/src/introspection.js
@@ -1,12 +1,13 @@
 const fetch = require("node-fetch");
 const config = require("./config");
 
-function verifyToken(request){
+async function verifyToken(request){
 
   var token;
+  var tokenData;
 
   //see if token provided in request
-  if(request.req.headers.hasOwnProperty("authorization")){
+  if(await request.req.headers.hasOwnProperty("authorization")){
     //remove "bearer" from token
     var splitReq = request.req.headers.authorization.split(" ");
     token = splitReq[1];
@@ -28,19 +29,20 @@ function verifyToken(request){
     body: "token=" + token
   };
 
-  fetch(url, postOptions)
+  await fetch(url, postOptions)
   .then((response) => response.json())
-  .then((data) => {
-    return data;
+  .then(function(data){ 
+    tokenData = data;
   })
   .catch((error) => {
     const errorMsg = {
       "active": false,
       "message": error.message
     };
-
-    return errorMsg;
+    tokenData = errorMsg;
   });
+
+  return tokenData;
 
 }
 


### PR DESCRIPTION
# Description

This fixes a race condition between Fetch and the auth directives.  The fix ensures the promise resolves before setting the value on the context which is used by the auth directives.

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Tested without the bugfix and the context.token is undefined.
- [x] Tested with the bugfix and the context.token is defined.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
