### PR TITLE
isSupervisor and isSameteam auth directives

### DIFF
--- a/src/Auth/Directives.js
+++ b/src/Auth/Directives.js
@@ -124,7 +124,7 @@ class SameTeamDirective extends SchemaDirectiveVisitor {
       }
 
       return await blockValue(field);
-    }
+    };
   }
 }
 
@@ -138,13 +138,13 @@ class SupervisorDirective extends SchemaDirectiveVisitor {
       const requestedSuper = await getSupervisorid(record);
 
       if(requester !== null && requestedSuper !== null){
-        if(requester == requestedSuper){
+        if(requester === requestedSuper){
             return resolve.apply(this, args);
         }
       }
 
       return await blockValue(field);
-    }
+    };
   }
 }
 

--- a/src/Auth/helpers.js
+++ b/src/Auth/helpers.js
@@ -7,12 +7,12 @@ const { GraphQLNonNull, GraphQLList } = require("graphql");
 /*
   The blockValue() function will ensure that a null value is never returned for a blocked field
   that is non-nullable.  In the case of when the a directive is placed at the query or mutation
-  level an Authentication error is thrown. 
+  level an Authentication error is thrown.
 */
 async function blockValue(field){
 
     var result = null;
-  
+
     if (field.type instanceof GraphQLNonNull){
       switch(field.type.ofType.name){
         case "EmailAddress":
@@ -24,14 +24,14 @@ async function blockValue(field){
         default:
           result = "";
       }
-      
+
       if (field.type.ofType instanceof GraphQLList){
         throw new AuthenticationError("Not Authorized");
       }
     }
-  
+
     return result;
-  
+
   }
 
   function getOrganizationid(profileObject){
@@ -44,7 +44,29 @@ async function blockValue(field){
     }
   }
 
+  function getTeamid(profileObject){
+    if (typeof profileObject !== "undefined" && propertyExists(profileObject, "team")){
+        if (propertyExists(profileObject, "team")){
+        return profileObject.team.id;
+        }
+    } else {
+        return null;
+    }
+  }
+
+  function getSupervisorid(profileObject){
+    if (typeof profileObject !== "undefined" && propertyExists(profileObject, "supervisor")){
+        if (propertyExists(profileObject, "supervisor")){
+        return profileObject.supervisor.gcID;
+        }
+    } else {
+        return null;
+    }
+  }
+
   module.exports= {
       blockValue,
-      getOrganizationid
+      getOrganizationid,
+      getTeamid,
+      getSupervisorid
   };

--- a/src/Auth/helpers.js
+++ b/src/Auth/helpers.js
@@ -36,9 +36,7 @@ async function blockValue(field){
 
   function getOrganizationid(profileObject){
     if (typeof profileObject !== "undefined" && propertyExists(profileObject.team, "organization")){
-        if (propertyExists(profileObject.team, "organization")){
         return profileObject.team.organization.id;
-        }
     } else {
         return null;
     }
@@ -46,9 +44,7 @@ async function blockValue(field){
 
   function getTeamid(profileObject){
     if (typeof profileObject !== "undefined" && propertyExists(profileObject, "team")){
-        if (propertyExists(profileObject, "team")){
         return profileObject.team.id;
-        }
     } else {
         return null;
     }
@@ -56,9 +52,7 @@ async function blockValue(field){
 
   function getSupervisorid(profileObject){
     if (typeof profileObject !== "undefined" && propertyExists(profileObject, "supervisor")){
-        if (propertyExists(profileObject, "supervisor")){
         return profileObject.supervisor.gcID;
-        }
     } else {
         return null;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,8 @@ const schema = makeExecutableSchema({
   schemaDirectives: {
     isAuthenticated: AuthDirectives.AuthenticatedDirective,
     inOrganization: AuthDirectives.OrganizationDirective,
+    isSameTeam: AuthDirectives.SameTeamDirective,
+    isSupervisor: AuthDirectives.SupervisorDirective
   },
   resolverValidationOptions: {
     requireResolversForResolveType: false
@@ -36,7 +38,7 @@ const schema = makeExecutableSchema({
 const server = new ApolloServer({
   schema,
   context: async (req) => ({
-    ...req,    
+    ...req,
     prisma: new Prisma({
       typeDefs: "./src/generated/prisma.graphql",
       endpoint: "http://"+config.prisma.host+":4466/profile/",

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -8,6 +8,13 @@ directive @inOrganization on FIELD_DEFINITION
 # The access token passed must be valid in order to proceed.
 directive @isAuthenticated on OBJECT | FIELD_DEFINITION
 
+# The @isSameTeam directive can be placed on a field of a Profile object and will only
+# return the field value if the requestor is on the same team
+directive @isSameTeam on FIELD_DEFINITION
+
+# The @isSupervisor directive can be placed on a field of a Profile object and will only
+# return the field value if the requestor is the assigned supervisor
+directive @isSupervisor on FIELD_DEFINITION
 
 scalar Email
 scalar PhoneNumber
@@ -24,9 +31,9 @@ type Query {
 type Mutation {
   createProfile(gcID: String!, name: String!, email: Email!, avatar: Upload, titleEn: String, titleFr: String, mobilePhone: PhoneNumber, officePhone: PhoneNumber, address: AddressInput, supervisor: SupervisorInput, team: TeamInput): Profile!
   modifyProfile(gcID: String!, data: ModifyProfileInput): Profile!
-  deleteProfile(gcID: String!): Boolean! 
+  deleteProfile(gcID: String!): Boolean!
   createTeam(nameEn: String!, nameFr: String!, organization: OrganizationInput! , owner: TeamOwnerInput!): Team!
-  modifyTeam(id: ID!, data: ModifyTeamInput): Team! 
+  modifyTeam(id: ID!, data: ModifyTeamInput): Team!
   deleteTeam(id: ID!): Boolean!
   createOrganization(nameEn: String!, nameFr: String!, acronymEn: String!, acronymFr: String!): Organization!
   modifyOrganization(id: ID!, data: ModifyOrganizationInput): Organization!
@@ -34,17 +41,17 @@ type Mutation {
 }
 
 type Profile {
-  gcID: String! 
-  name: String! 
-  email: Email! 
-  avatar: String 
-  mobilePhone: PhoneNumber 
+  gcID: String!
+  name: String!
+  email: Email!
+  avatar: String
+  mobilePhone: PhoneNumber
   officePhone: PhoneNumber
   address: Address
-  titleEn: String 
-  titleFr: String 
-  supervisor: Profile 
-  team: Team     
+  titleEn: String
+  titleFr: String
+  supervisor: Profile
+  team: Team
 }
 
 type Address {
@@ -55,10 +62,10 @@ type Address {
   postalCode: String!
   country: String!,
   resident: Profile!
-} 
+}
 
 type Team {
-  id: ID! 
+  id: ID!
   nameEn: String!
   nameFr: String!
   organization: Organization!
@@ -67,7 +74,7 @@ type Team {
 }
 
 type Organization {
-  id: ID! 
+  id: ID!
   nameEn: String!
   nameFr: String!
   acronymEn: String!
@@ -115,8 +122,8 @@ input ModifyProfileInput {
   address: AddressInput
   titleEn: String
   titleFr: String
-  supervisor: SupervisorInput 
-  team: TeamInput   
+  supervisor: SupervisorInput
+  team: TeamInput
 }
 
 input ModifyTeamInput {


### PR DESCRIPTION
# Description

Adds two new schema directives that allow us to check if the requester is on the same team or is the assigned supervisor.

**@isSameTeam**: Verify if the requester is on the same team as the record being retrieved.

**@isSupervisor**: Verify if the requester is the assigned supervisor on the record being retrieved.

# Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Using three different profiles, profile 1 and 2 were on the same team and had profile 1 set as supervisor for both. Profile 3 was on a different team but had profile 2 as a supervisor.

- [x] Set @isSameteam on email field from profiles query. When queried as P1, the email fields are returned for P1 and P2 while P3's email return blocked.
- [x] Set @isSupervisor on email field in profiles query. When queried as P1, the email fields are returned for P1 and P2 while P3's email return blocked.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
