### PR TITLE
Add owner directive

### DIFF
--- a/src/Auth/Directives.js
+++ b/src/Auth/Directives.js
@@ -1,7 +1,7 @@
 const { SchemaDirectiveVisitor, AuthenticationError } = require("apollo-server");
 const { propertyExists } = require("../resolvers/helper/objectHelper");
 const { defaultFieldResolver } = require("graphql");
-const { blockValue, getOrganizationid } = require("./helpers");
+const { blockValue, getOrganizationid, getOwnerid } = require("./helpers");
 
 /*
   Fragments for Auth:
@@ -108,11 +108,34 @@ class AuthenticatedDirective extends SchemaDirectiveVisitor {
   }
 }
 
+class OwnerDirective extends SchemaDirectiveVisitor {
 
+  visitObject(type){
+    this.wrapOwnerAuth(type);
+    type._requiresOwAuth = true;
+  }
+    
+  visitFieldDefinition(field) {
+    const { resolve = defaultFieldResolver } = field;
+    field.resolve = async function (record, args, context, info){
 
+      const OwnerRequester = await getOwnerid(context.token.owner);
+      const OwnerRequested = await getOwnerid(record);
+
+      if(OwnerRequester !== null && OwnerRequested !== null){
+        if(OwnerRequester == OwnerRequested){
+            return resolve.apply(this, [record, args, context, info]);
+        }
+      }
+
+      return await blockValue(field);
+    }
+  }
+}
 
 module.exports = {
   OrganizationDirective,
   AuthenticatedDirective,
+  OwnerDirective,
   profileFragment
 };

--- a/src/Auth/Directives.js
+++ b/src/Auth/Directives.js
@@ -109,11 +109,6 @@ class AuthenticatedDirective extends SchemaDirectiveVisitor {
 }
 
 class OwnerDirective extends SchemaDirectiveVisitor {
-
-  visitObject(type){
-    this.wrapOwnerAuth(type);
-    type._requiresOwAuth = true;
-  }
     
   visitFieldDefinition(field) {
     const { resolve = defaultFieldResolver } = field;
@@ -123,13 +118,13 @@ class OwnerDirective extends SchemaDirectiveVisitor {
       const OwnerRequested = await getOwnerid(record);
 
       if(OwnerRequester !== null && OwnerRequested !== null){
-        if(OwnerRequester == OwnerRequested){
+        if(OwnerRequester === OwnerRequested){
             return resolve.apply(this, [record, args, context, info]);
         }
       }
 
       return await blockValue(field);
-    }
+    };
   }
 }
 

--- a/src/Auth/helpers.js
+++ b/src/Auth/helpers.js
@@ -43,11 +43,10 @@ async function blockValue(field){
   }
 
 function getOwnerid(profileObject){
-  if (typeof profileObject !== "undefined"){
-      if (propertyExists(profileObject, "profile")){
-      return profileObject.profile.gcID;
+  if (typeof profileObject !== "undefined" && propertyExists(profileObject, "gcID")){
+      return profileObject.gcID;
       }
-  } else {
+  else {
       return null;
   }
 }

--- a/src/Auth/helpers.js
+++ b/src/Auth/helpers.js
@@ -3,7 +3,6 @@ const {  AuthenticationError } = require("apollo-server");
 const { propertyExists } = require("../resolvers/helper/objectHelper");
 const { GraphQLNonNull, GraphQLList } = require("graphql");
 
-
 /*
   The blockValue() function will ensure that a null value is never returned for a blocked field
   that is non-nullable.  In the case of when the a directive is placed at the query or mutation
@@ -12,7 +11,6 @@ const { GraphQLNonNull, GraphQLList } = require("graphql");
 async function blockValue(field){
 
     var result = null;
-  
     if (field.type instanceof GraphQLNonNull){
       switch(field.type.ofType.name){
         case "EmailAddress":
@@ -29,7 +27,7 @@ async function blockValue(field){
         throw new AuthenticationError("Not Authorized");
       }
     }
-  
+
     return result;
   
   }
@@ -44,7 +42,18 @@ async function blockValue(field){
     }
   }
 
+function getOwnerid(profileObject){
+  if (typeof profileObject !== "undefined"){
+      if (propertyExists(profileObject, "profile")){
+      return profileObject.profile.gcID;
+      }
+  } else {
+      return null;
+  }
+}
+
   module.exports= {
       blockValue,
-      getOrganizationid
+      getOrganizationid,
+      getOwnerid
   };

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,8 @@ const schema = makeExecutableSchema({
   schemaDirectives: {
     isAuthenticated: AuthDirectives.AuthenticatedDirective,
     inOrganization: AuthDirectives.OrganizationDirective,
+    isOwner: AuthDirectives.OwnerDirective,
+    
   },
   resolverValidationOptions: {
     requireResolversForResolveType: false

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -8,6 +8,7 @@ directive @inOrganization on FIELD_DEFINITION
 # The access token passed must be valid in order to proceed.
 directive @isAuthenticated on OBJECT | FIELD_DEFINITION
 
+directive @isOwner on FIELD_DEFINITION
 
 scalar Email
 scalar PhoneNumber

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -8,6 +8,8 @@ directive @inOrganization on FIELD_DEFINITION
 # The access token passed must be valid in order to proceed.
 directive @isAuthenticated on OBJECT | FIELD_DEFINITION
 
+# The @isOwner directive can be placed on a filed of a Profile object and will only
+# return the field value if the requestor is the owner (has the same gcID)
 directive @isOwner on FIELD_DEFINITION
 
 scalar Email
@@ -37,7 +39,7 @@ type Mutation {
 type Profile {
   gcID: String! 
   name: String! 
-  email: Email! 
+  email: Email!
   avatar: String 
   mobilePhone: PhoneNumber 
   officePhone: PhoneNumber


### PR DESCRIPTION
# Description

Add schema directive for Owner. Give access to field if the user is the owner.

Fixes https://zube.io/tbs-sct/gctools/c/3865

# Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Add isOwner directive to email profile. Create a two dummy profile. Using dummy.profile1 try access the email of dummy.profile2.

Using dummy.profile2 try access is own email.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
