### PR TITLE
Team logic for when a team is deleted

### DIFF
--- a/src/resolvers/Mutations.js
+++ b/src/resolvers/Mutations.js
@@ -1,5 +1,5 @@
 const {copyValueToObjectIfDefined, propertyExists} = require("./helper/objectHelper");
-const { throwExceptionIfProfileIsNotDefined, changeOwnedTeamsRoot} = require("./helper/profileHelper");
+const { throwExceptionIfProfileIsNotDefined, changeOwnedTeamsRoot, moveMembersToDefaultTeam} = require("./helper/profileHelper");
 const { getNewAddressFromArgs, updateOrCreateAddressOnProfile} = require("./helper/addressHelper");
 const {processUpload} = require("./File-Upload");
 const { UserInputError } = require("apollo-server");
@@ -271,6 +271,10 @@ async function deleteTeam(_, args, context){
     // eslint-disable-next-line new-cap
     if (await context.prisma.exists.Team({id:args.id})){
         try {
+
+            await moveMembersToDefaultTeam(args.id, context);
+
+
             await context.prisma.mutation.deleteTeam({
                 where:{
                     id: args.id

--- a/src/resolvers/Mutations.js
+++ b/src/resolvers/Mutations.js
@@ -273,8 +273,6 @@ async function deleteTeam(_, args, context){
         try {
 
             await moveMembersToDefaultTeam(args.id, context);
-
-
             await context.prisma.mutation.deleteTeam({
                 where:{
                     id: args.id

--- a/src/resolvers/helper/default_setup.js
+++ b/src/resolvers/helper/default_setup.js
@@ -32,6 +32,8 @@ async function createDefaultOrg() {
 }
 
 async function getDefaults(){
+
+    // Set defaults on context 
     var org = await querys.organizations({},{nameEn:"Default Organization", nameFr:"Organization par défaut"}, ctx, "{id}");
     if (org.length < 1 ){
         defaultData.org = await createDefaultOrg();

--- a/src/resolvers/helper/profileHelper.js
+++ b/src/resolvers/helper/profileHelper.js
@@ -66,7 +66,7 @@ async function moveMembersToDefaultTeam(teamID, context){
   
   const teamInfo = await context.prisma.query.team({where:{id: teamID}},"{members { gcID }, owner{gcID}}");
   const defaultTeam = await context.prisma.query.teams({where:{owner:{gcID: teamInfo.owner.gcID}, nameEn: "User Default Team"}}, "{id}");
-
+  // TODO: Batch into a single call instead of multiple.
   if (typeof defaultTeam[0] !== "undefined" && defaultTeam[0] !== null){
     for (let x = 0; x < teamInfo.members.length; x++){
       await context.prisma.mutation.updateTeam({where:{id: defaultTeam[0].id}, data:{members:{connect:{gcID: teamInfo.members[x].gcID}}}});

--- a/src/resolvers/helper/profileHelper.js
+++ b/src/resolvers/helper/profileHelper.js
@@ -13,7 +13,7 @@ async function getTeams(userID, context){
 }
 
 
-
+// Recursive funtion to cascade and move organizations
 async function changeTeamOrg(teams, context, newOrgID){
 
   for (let t = 0; t < teams.ownerOfTeams.length; t++){

--- a/src/resolvers/helper/profileHelper.js
+++ b/src/resolvers/helper/profileHelper.js
@@ -60,7 +60,23 @@ async function changeOwnedTeamsRoot(userID, newTeamID, context){
   
 }
 
+async function moveMembersToDefaultTeam(teamID, context){
+  const teamInfo = await context.prisma.query.team({where:{id: teamID}},"{members { gcID }, owner{gcID}}");
+  const defaultTeam = await context.prisma.query.teams({where:{owner:{gcID: teamInfo.owner.gcID}, nameEn: "User Default Team"}}, "{id}");
+
+  if (typeof defaultTeam[0] !== "undefined" && defaultTeam[0] !== null){
+    for (let x = 0; x < teamInfo.members.length; x++){
+      await context.prisma.mutation.updateTeam({where:{id: defaultTeam[0].id}, data:{members:{connect:{gcID: teamInfo.members[x].gcID}}}});
+    }
+
+  }
+
+  
+
+}
+
 module.exports ={
   throwExceptionIfProfileIsNotDefined,
-  changeOwnedTeamsRoot
+  changeOwnedTeamsRoot,
+  moveMembersToDefaultTeam
 };

--- a/src/resolvers/helper/profileHelper.js
+++ b/src/resolvers/helper/profileHelper.js
@@ -61,6 +61,9 @@ async function changeOwnedTeamsRoot(userID, newTeamID, context){
 }
 
 async function moveMembersToDefaultTeam(teamID, context){
+
+  //TODO: Add error handling to send errors to MQ
+  
   const teamInfo = await context.prisma.query.team({where:{id: teamID}},"{members { gcID }, owner{gcID}}");
   const defaultTeam = await context.prisma.query.teams({where:{owner:{gcID: teamInfo.owner.gcID}, nameEn: "User Default Team"}}, "{id}");
 

--- a/tests/init/helper.js
+++ b/tests/init/helper.js
@@ -1,6 +1,7 @@
 const { Prisma } = require("prisma-binding");
 const { getDefaults } = require("../../src/resolvers/helper/default_setup");
 
+// Set prisma object on context
 function setPrisma(context){
 
   context.prisma = new Prisma({
@@ -10,7 +11,7 @@ function setPrisma(context){
     return context;
 }
 
-
+// Setup of context object
 const getContext = async () => {
   var ctx = {};
   ctx.prisma = await new Prisma({
@@ -22,6 +23,7 @@ const getContext = async () => {
   return ctx;
 };
 
+// Wipe the database clean
 async function cleanUp(context){
   await context.prisma.mutation.deleteManyAddresses();
   await context.prisma.mutation.deleteManyProfiles();

--- a/tests/teamAndOrganizationLogic.test.js
+++ b/tests/teamAndOrganizationLogic.test.js
@@ -143,7 +143,7 @@ describe("Org chart Logic", () => {
     
 
 
-    beforeAll((done) => {
+    beforeEach((done) => {
 
         createProfiles(profiles).then(() => {
             createOrganizations(orgs).then((orgIDs) => {
@@ -173,6 +173,14 @@ describe("Org chart Logic", () => {
         });   
     });
 
+    afterEach((done) => {
+        getContext().then((ctx) => {
+          return cleanUp(ctx);  
+        }).then(() => {
+            done();
+        });
+
+    });
 
     it("Profile's default team should inherit department", async() => {
 
@@ -189,7 +197,7 @@ describe("Org chart Logic", () => {
 
         const orgData = await querys.organizations({}, {nameEn:"Org 2"}, ctx, "{teams {id, nameEn } }");
 
-        var result = await mutations.modifyProfile({},{gcID:"10", data:{ team:{ id: orgData[0].teams[0].id}}} , ctx, "{ team {id, organization { nameEn } } }");
+        await mutations.modifyProfile({},{gcID:"10", data:{ team:{ id: orgData[0].teams[0].id}}} , ctx, "{ team {id, organization { nameEn } } }");
 
         const query = "query orgTest { profiles(gcID: \"50\") { gcID, team { organization { nameEn } } } }";
         const queryData =await graphql(schema, query);            
@@ -200,13 +208,25 @@ describe("Org chart Logic", () => {
 
     });
 
-    afterAll((done) => {
-        getContext().then((ctx) => {
-          cleanUp(ctx);  
-        }).then(() => {
-            done();
-        });
+    it("Deleted teams members should be transferred to the supervisors default team", async() => {
+        const ctx = await getContext();
+
+        const teamData = await querys.teams({},{nameEn:"Team 3"}, ctx, "{id}");
+
+        const deleteSuccess = await mutations.deleteTeam({},{id: teamData[0].id}, ctx);
+
+        const query = "query orgTest { profiles(gcID: \"40\") { gcID, team { nameEn, owner { gcID } } } }";
+        const queryData = await graphql(schema, query);
+
+
+        expect(queryData.data.profiles[0].team.owner.gcID).toEqual("30");
+        expect(queryData.data.profiles[0].team.nameEn).toEqual("User Default Team");
+        expect(deleteSuccess).toBeTruthy();    
+
+
 
     });
+
+
 
 });


### PR DESCRIPTION
# Description

When a team is deleted the members of that team are now returned to the supervisors default team.  The handler logic can now be removed from the front end (Directory-fe)

# Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

Tests written in `./tests/teamAndOrganizationLogic` with name "Deleted team members should be transferred to the supervisors default team"
- [x] Delete team with members and query members to ensure team has been modified to "User Default Team" with same supervisor/team owner.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
