### PR TITLE
Team logic for when supervisors transfer teams

### DIFF
--- a/prisma/datamodel.graphql
+++ b/prisma/datamodel.graphql
@@ -84,4 +84,5 @@ enum Status {
 enum ChangeType {
     Membership
     Informational
+    Team
 } 

--- a/prisma/datamodel.graphql
+++ b/prisma/datamodel.graphql
@@ -37,6 +37,8 @@ type Team {
   organization: Organization! @relation(name:"Teams")
   owner: Profile @relation(name:"OwnerOfTeam")
   members: [Profile!]! @relation(name:"TeamMembers")
+  transferApproval: RequestedChange @relation(name:"TransferOwnershipTo")
+  supervisorApproval: [RequestedChange] @relation(name:"SupervisoryApproval")
 }
 
 type Organization {
@@ -73,7 +75,8 @@ type RequestedChange {
     address: Address
     titleEn: String
     titleFr: String
-    team: Team
+    team: Team @relation(name:"SupervisoryApproval")
+    ownershipOfTeam: Team @relation(name:"TransferOwnershipTo")
 }
 
 enum Status {

--- a/src/Middleware/authMiddleware.js
+++ b/src/Middleware/authMiddleware.js
@@ -57,7 +57,7 @@ const allowedToModifyApproval = async (resolve, root, args, context, info) => {
         return await resolve(root, args, context, info);
     }
 
-    if(approval.changeType === "Membership"){
+    if(approval.changeType === "Membership" || approval.changeType === "Team"){
         if(approval.gcIDApprover.gcID !== context.token.owner.gcID){
             throw new AuthenticationError("Must be supervisor of the team to accept transfer request");
         }

--- a/src/Middleware/authMiddleware.js
+++ b/src/Middleware/authMiddleware.js
@@ -1,6 +1,6 @@
 const { AuthenticationError } = require("apollo-server");
 const { removeNullKeys, cloneObject } = require("../resolvers/helper/objectHelper");
-const {getProfile} = require("./common");
+const {getProfile, getTeam} = require("./common");
 
 
 const allowedToModifyProfile = async (resolve, root, args, context, info) => {
@@ -13,6 +13,16 @@ const allowedToModifyProfile = async (resolve, root, args, context, info) => {
     }
     return await resolve(root, args, context, info);
     
+};
+
+const allowedToModifyTeam = async (resolve, root, args, context, info) => {
+    // Only the current team owner can modify a team
+    const existingTeam = await getTeam(context, args.id);
+    if (existingTeam.owner.gcID !== context.token.owner.gcID){
+        throw new AuthenticationError("Must be owner of team to modify");
+    }
+    return await resolve(root, args, context, info);
+
 };
 
 const allowedToModifyApproval = async (resolve, root, args, context, info) => {
@@ -70,6 +80,7 @@ const mustbeAuthenticated = async (resolve, root, args, context, info) => {
 
 module.exports={
     allowedToModifyProfile,
+    allowedToModifyTeam,
     allowedToModifyApproval,
     mustbeAuthenticated
 

--- a/src/Middleware/authMiddleware.js
+++ b/src/Middleware/authMiddleware.js
@@ -1,20 +1,13 @@
 const { AuthenticationError } = require("apollo-server");
 const { removeNullKeys, cloneObject } = require("../resolvers/helper/objectHelper");
+const {getProfile} = require("./common");
 
-
-async function getSubmitterProfile(context, args){
-    return await context.prisma.query.profile({
-        where:{
-            gcID: args.gcID
-        }
-    },"{gcID, name, email, avatar, mobilePhone, officePhone, titleEn, titleFr, address{streetAddress, city, province, postalCode, country},team{id,organization{id},owner{gcID}}}");
-}
 
 const allowedToModifyProfile = async (resolve, root, args, context, info) => {
 
     // Only the profile owner or their current supervisor can modify a profile
     
-    const submitter = await getSubmitterProfile(context, args);
+    const submitter = await getProfile(context, args);
     if (args.gcID !== context.token.owner.gcID && context.token.owner.gcID !== submitter.team.owner.gcID){
         throw new AuthenticationError("Must be owner or supervisor of profile to Modify");
     }

--- a/src/Middleware/common.js
+++ b/src/Middleware/common.js
@@ -1,4 +1,4 @@
-async function getSubmitterProfile(context, args){
+async function getProfile(context, args){
     return await context.prisma.query.profile({
         where:{
             gcID: args.gcID
@@ -49,7 +49,7 @@ async function getApprovalType(approvals, type){
 }
 
 module.exports = {
-    getSubmitterProfile,
+    getProfile,
     checkForDirective,
     checkForEmptyChanges,
     getApprovalType

--- a/src/Middleware/common.js
+++ b/src/Middleware/common.js
@@ -1,0 +1,56 @@
+async function getSubmitterProfile(context, args){
+    return await context.prisma.query.profile({
+        where:{
+            gcID: args.gcID
+        }
+    },"{gcID, name, email, avatar, mobilePhone, officePhone, titleEn, titleFr, address{streetAddress, city, province, postalCode, country},team{id,organization{id},owner{gcID}}}");
+}
+
+function checkForDirective(field, info, directiveName){
+    const fieldDirectives = info.returnType.ofType._fields[field].astNode.directives;
+    var directiveExists = false;
+    if (fieldDirectives.length > 0){
+        fieldDirectives.forEach((directive) => {
+            if (directive.name.value === directiveName){
+                directiveExists = true;
+                return;
+            }
+        });
+    }
+    return directiveExists;
+}
+
+function checkForEmptyChanges(changesObject){
+    // Return True if requestedChanges is all null
+
+    var requestedChanges = JSON.parse(JSON.stringify(changesObject));
+    var isNull = true;
+    
+    Object.entries(requestedChanges).forEach((field) => {
+        isNull = isNull && !field;
+    });
+
+    return isNull;
+}
+
+async function getApprovalType(approvals, type){
+
+    if(approvals){
+        const index = approvals.findIndex((approval) => {
+            return approval.changeType === type;
+        });
+    
+        if (index >= 0){
+            return approvals[index];
+        }
+    }
+
+    return null;
+}
+
+module.exports = {
+    getSubmitterProfile,
+    checkForDirective,
+    checkForEmptyChanges,
+    getApprovalType
+};

--- a/src/Middleware/profileApprovalCreation.js
+++ b/src/Middleware/profileApprovalCreation.js
@@ -1,18 +1,12 @@
 const { createApproval, appendApproval } = require("../resolvers/helper/approvalHelper");
 const { removeNullKeys, cloneObject } = require("../resolvers/helper/objectHelper");
-const { getSubmitterProfile, checkForDirective, checkForEmptyChanges, getApprovalType } = require("./common");
+const { getProfile, checkForDirective, checkForEmptyChanges, getApprovalType } = require("./common");
 
 /*-------------------------------------------------------------------------
 User submits changes with both memembership and Informational
  - Create 2 approvals with new supervisor
  - New supervisor cannot approve information until membership approved
  - Denying membership also cancels the associated informational change
-
-
-
-
-
-
 --------------------------------------------------------------------------*/
 
 async function isThereATeamOwner(teamID, context){
@@ -210,7 +204,7 @@ const profileApprovalRequired = async (resolve, root, args, context, info) => {
     requestedChanges.data = {};
     requestedChanges.createdBy = context.token.owner.gcID;
     requestedChanges.updatedBy = context.token.owner.gcID;
-    const submitter = await getSubmitterProfile(context, args);
+    const submitter = await getProfile(context, args);
     requestedChanges.approvalSubmitter = submitter.gcID;
     requestedChanges.approverID = await whoIsTheApprover(context, args, submitter);
 

--- a/src/Middleware/profileApprovalCreation.js
+++ b/src/Middleware/profileApprovalCreation.js
@@ -1,5 +1,4 @@
-const {createApproval, appendApproval} = require("../resolvers/helper/approvalHelper");
-const { AuthenticationError } = require("apollo-server");
+const { createApproval, appendApproval } = require("../resolvers/helper/approvalHelper");
 const { removeNullKeys, cloneObject } = require("../resolvers/helper/objectHelper");
 
 /*-------------------------------------------------------------------------
@@ -265,7 +264,7 @@ async function generateInformationalApproval(informationalChanges, context, appr
 }
 
 
-const approvalRequired = async (resolve, root, args, context, info) => {
+const profileApprovalRequired = async (resolve, root, args, context, info) => {
 
     var requestedChanges = {};
     requestedChanges.data = {};
@@ -340,5 +339,5 @@ const approvalRequired = async (resolve, root, args, context, info) => {
 
 
 module.exports ={
-    approvalRequired
+    profileApprovalRequired
 };

--- a/src/Middleware/profileApprovalCreation.js
+++ b/src/Middleware/profileApprovalCreation.js
@@ -1,5 +1,6 @@
 const { createApproval, appendApproval } = require("../resolvers/helper/approvalHelper");
 const { removeNullKeys, cloneObject } = require("../resolvers/helper/objectHelper");
+const { getSubmitterProfile, checkForDirective, checkForEmptyChanges, getApprovalType } = require("./common");
 
 /*-------------------------------------------------------------------------
 User submits changes with both memembership and Informational
@@ -13,47 +14,6 @@ User submits changes with both memembership and Informational
 
 
 --------------------------------------------------------------------------*/
-
-
-
-function checkForDirective(field, info){
-    const directiveName = "requiresApproval";
-    const fieldDirectives = info.returnType.ofType._fields[field].astNode.directives;
-    var directiveExists = false;
-    if (fieldDirectives.length > 0){
-        fieldDirectives.forEach((directive) => {
-            if (directive.name.value === directiveName){
-                directiveExists = true;
-                return;
-            }
-        });
-    }
-    return directiveExists;
-
-
-}
-
-async function getSubmitterProfile(context, args){
-    return await context.prisma.query.profile({
-        where:{
-            gcID: args.gcID
-        }
-    },"{gcID, name, email, avatar, mobilePhone, officePhone, titleEn, titleFr, address{streetAddress, city, province, postalCode, country},team{id,organization{id},owner{gcID}}}");
-}
-
-function checkForEmptyChanges(changesObject){
-    // Return True if requestedChanges is all null
-
-    var requestedChanges = JSON.parse(JSON.stringify(changesObject));
-    var isNull = true;
-    
-    Object.entries(requestedChanges).forEach((field) => {
-        isNull = isNull && !field;
-    });
-
-    return isNull;
-
-}
 
 async function isThereATeamOwner(teamID, context){
     
@@ -140,22 +100,6 @@ async function checkAgainstExistingProfile(requestedChanges, submitterProfile){
     });
 }
 
-async function getApprovalType(approvals, type){
-
-    if(approvals){
-        const index = approvals.findIndex((approval) => {
-            return approval.changeType === type;
-        });
-    
-        if (index >= 0){
-            return approvals[index];
-        }
-    }
-
-    return null;
-
-}
-
 async function getNewSupervisor(context, gcID){
     return await getExistingApprovals(context, gcID)
     .then((approvals) => {
@@ -168,7 +112,6 @@ async function getNewSupervisor(context, gcID){
         return null;
     });
 }
-
 
 async function whoIsTheApprover(context, args, submitterProfile){
     const newTeamOwner = await isThereATeamOwner(args.data.team, context);
@@ -184,9 +127,6 @@ async function whoIsTheApprover(context, args, submitterProfile){
         }        
     }
 }
-
-
-
 
 async function generateMemerbshipApproval(membershipChanges, context, approvals = null){
     if (membershipChanges.data.team){
@@ -283,7 +223,7 @@ const profileApprovalRequired = async (resolve, root, args, context, info) => {
     for (var field in args.data){
         // Find any fields wrapped with the @requiresApproval directive and
         // remove them from the current context
-        if (await checkForDirective(field, info)){
+        if (await checkForDirective(field, info, "requiresApproval")){
             requestedChanges.data[field] = args.data[field];
             delete args.data[field];
         }
@@ -324,19 +264,11 @@ const profileApprovalRequired = async (resolve, root, args, context, info) => {
                 generateMemerbshipApproval(cloneObject(requestedChanges), context, existingApprovals),
                 generateInformationalApproval(cloneObject(requestedChanges), context, existingApprovals)
             ]);
-    }
-    
-
+    }  
 
     // mutate any remainng non protected fields and resolve info
-    return await resolve(root, args, context, info);
-       
-
+    return await resolve(root, args, context, info);  
 };
-
-
-
-
 
 module.exports ={
     profileApprovalRequired

--- a/src/Middleware/profileApprovalCreation.js
+++ b/src/Middleware/profileApprovalCreation.js
@@ -1,6 +1,6 @@
 const { createApproval, appendApproval } = require("../resolvers/helper/approvalHelper");
 const { removeNullKeys, cloneObject } = require("../resolvers/helper/objectHelper");
-const { getProfile, checkForDirective, checkForEmptyChanges, getApprovalType } = require("./common");
+const { getProfile, checkForDirective, checkForEmptyChanges, getApprovalType, getExistingApprovals } = require("./common");
 
 /*-------------------------------------------------------------------------
 User submits changes with both memembership and Informational
@@ -23,44 +23,7 @@ async function isThereATeamOwner(teamID, context){
     return owner;
 }
 
-async function getExistingApprovals(context, gcID){
-    return await context.prisma.query.approvals({
-        where:{
-            status: "Pending",
-            gcIDSubmitter:{
-                gcID
-            }
-        }
-    }, 
-    `{
-        id,
-        gcIDApprover{
-            gcID
-        },
-        status,
-        changeType,
-        requestedChange{
-            id,
-            name,
-            email,
-            avatar,
-            mobilePhone,
-            officePhone,
-            address{
-            streetAddress,
-            city,
-            province,
-            postalCode,
-            country
-            },
-            titleEn,
-            titleFr,
-            team{
-                id
-            }   
-        }
-    }`);
-}
+
 
 async function checkAgainstExistingApprovals(requestedChanges, approvals) {
 

--- a/src/Middleware/teamApprovalCreation.js
+++ b/src/Middleware/teamApprovalCreation.js
@@ -1,30 +1,63 @@
 const { createApproval, appendApproval } = require("../resolvers/helper/approvalHelper");
-const { removeNullKeys, cloneObject } = require("../resolvers/helper/objectHelper");
-const {getProfile} = require("./common");
+const { cloneObject } = require("../resolvers/helper/objectHelper");
+const { getTeam, getExistingApprovals, getApprovalType} = require("./common");
 
-async function getTeam(context, id){
-   return await context.prisma.query.team({
-        where:{
-            id
-        }
-    }, "{owner{gcID}}");
+async function generateTeamTransferApproval(context, existingTeam, newOwner){
+    // Check to see if there is an existing transfer for this specific team
+
+    const existingApprovals = await getExistingApprovals(context, context.token.owner.gcID, existingTeam)
+    .then((approvals) => getApprovalType(approvals, "Team"))
+    .catch((e) => {
+        // eslint-disable-next-line no-console
+        console.error(e);
+    });
+
+    var ownershipTransferObject = {
+        gcIDApprover: newOwner.gcID,
+        gcIDSubmitter: context.token.owner.gcID,
+        createdBy: context.token.owner.gcID,
+        requestedChange: {
+            ownershipOfTeam:{
+                id: existingTeam.id
+            }
+        },
+        changeType: "Team"
+    };    
+
+    // Append existing transfer with new owner
+
+    if (existingApprovals){
+        ownershipTransferObject.id = existingApprovals.id;
+        await appendApproval(null, ownershipTransferObject, context)
+        .catch((e) => {
+            // eslint-disable-next-line no-console
+            console.log(e);
+        });
+    } else {
+        // Create new transfer if none already exist
+        await createApproval(null, ownershipTransferObject, context)
+        .catch((e) => {
+            // eslint-disable-next-line no-console
+            console.log(e);
+        });
+    }
+
+    return;
 }
 
 const teamApprovalRequired = async (resolve, root, args, context, info) => {
 
     const existingTeam = await getTeam(context, args.id);
 
-    if (args.data.owner && (args.data.owner.gcID === existingTeam.owner.gcID || !args.data.owner.gcID)){
-        // No change in ownership
-        return await resolve(root, args, context, info);
-    }       
-        
+    if (args.data.owner && args.data.owner.gcID !== existingTeam.owner.gcID){
+        // change in ownership
+        // clone args object so we don't need to wait for generate team transfer to return.
+        generateTeamTransferApproval(context, existingTeam, cloneObject(args.data.owner));
+        delete args.data.owner;
+    }
+
+    // resolve remaining mutation for non ownership changes
     return await resolve(root, args, context, info);
-
-
-
-
-
 };
 
 module.exports = {

--- a/src/Middleware/teamApprovalCreation.js
+++ b/src/Middleware/teamApprovalCreation.js
@@ -1,4 +1,19 @@
+const { createApproval, appendApproval } = require("../resolvers/helper/approvalHelper");
+const { removeNullKeys, cloneObject } = require("../resolvers/helper/objectHelper");
+const {getSubmitterProfile} = require("./common");
+
 const teamApprovalRequired = async (resolve, root, args, context, info) => {
+    var requestedChanges = {};
+    requestedChanges.data = {};
+    requestedChanges.createdBy = context.token.owner.gcID;
+    requestedChanges.updatedBy = context.token.owner.gcID;
+    const submitter = await getSubmitterProfile(context, args);
+    requestedChanges.approvalSubmitter = submitter.gcID;
+
+
+
+
+
 };
 
 module.exports = {

--- a/src/Middleware/teamApprovalCreation.js
+++ b/src/Middleware/teamApprovalCreation.js
@@ -1,0 +1,6 @@
+const teamApprovalRequired = async (resolve, root, args, context, info) => {
+};
+
+module.exports = {
+    teamApprovalRequired
+};

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,8 @@ const { connectMessageQueuePublisher } = require("./Service_Mesh/publisher_conne
 const introspect = require("./Auth/introspection");
 const { getDefaults } = require("./resolvers/helper/default_setup");
 const { applyMiddleware } = require("graphql-middleware");
-const { approvalRequired } = require("./Middleware/approvalCreation");
+const { profileApprovalRequired } = require("./Middleware/profileApprovalCreation");
+const { teamApprovalRequired } = require("./Middleware/teamApprovalCreation");
 const {allowedToModifyProfile, allowedToModifyApproval, mustbeAuthenticated} = require("./Middleware/authMiddleware");
 
 const resolvers = {
@@ -29,10 +30,16 @@ const resolvers = {
   PostalCode
 };
 
-const approvalRequiredApplications = {
+const profileApprovalRequiredApplications = {
   Mutation:{
-    modifyProfile: approvalRequired
+    modifyProfile: profileApprovalRequired
   },  
+};
+
+const teamApprovalRequiredApplications = {
+  Mutation:{
+    modifyTeam: teamApprovalRequired
+  },
 };
 
 const ownershipRequiredApplications = {
@@ -75,7 +82,8 @@ const schema = applyMiddleware(
   schemaBeforeMiddleware,
   authenticationRequiredApplications,
   ownershipRequiredApplications,
-  approvalRequiredApplications,
+  profileApprovalRequiredApplications,
+  teamApprovalRequiredApplications,
 );
 
 const server = new ApolloServer({

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const { getDefaults } = require("./resolvers/helper/default_setup");
 const { applyMiddleware } = require("graphql-middleware");
 const { profileApprovalRequired } = require("./Middleware/profileApprovalCreation");
 const { teamApprovalRequired } = require("./Middleware/teamApprovalCreation");
-const {allowedToModifyProfile, allowedToModifyApproval, mustbeAuthenticated} = require("./Middleware/authMiddleware");
+const {allowedToModifyProfile, allowedToModifyApproval, allowedToModifyTeam, mustbeAuthenticated} = require("./Middleware/authMiddleware");
 
 const resolvers = {
   Query,
@@ -45,7 +45,8 @@ const teamApprovalRequiredApplications = {
 const ownershipRequiredApplications = {
   Mutation:{
     modifyProfile: allowedToModifyProfile,
-    modifyApproval: allowedToModifyApproval 
+    modifyApproval: allowedToModifyApproval,
+    modifyTeam: allowedToModifyTeam 
   },
 };
 

--- a/src/resolvers/Mutations.js
+++ b/src/resolvers/Mutations.js
@@ -320,7 +320,16 @@ async function modifyApproval(_, args, context, info){
     
     if (args.data.status === "Approved"){
         const approvedChanges = await getApprovalChanges(args.id, context);
-        modifyProfile(_, approvedChanges, context);
+        if (approvedChanges.changeType === ("Membership" || "Informational")){
+            delete approvedChanges.changeType;
+            modifyProfile(_, approvedChanges, context);
+        }
+        if(approvedChanges.changeType === "Team"){
+            delete approvedChanges.changeType;
+            modifyTeam(_, approvedChanges, context);
+        }
+
+
     }
 
     return await context.prisma.mutation.updateApproval({

--- a/src/resolvers/helper/approvalHelper.js
+++ b/src/resolvers/helper/approvalHelper.js
@@ -1,16 +1,16 @@
-const {copyValueToObjectIfDefined} = require("./objectHelper");
+const {copyValueToObjectIfDefined, removeNullKeys} = require("./objectHelper");
 const { getNewAddressFromArgs} = require("./addressHelper");
 const { UserInputError } = require("apollo-server");
 
 async function createApproval(_, args, context, info){
     var address = (args.requestedChange.address) ? getNewAddressFromArgs(args.requestedChange) : null;
 
-    const data = {
+    const data = removeNullKeys({
             gcIDApprover: {connect: {gcID: args.gcIDApprover}},
             gcIDSubmitter: {connect: {gcID: args.gcIDSubmitter}},
             createdBy: {connect: {gcID: args.createdBy}},
             requestedChange: {
-                create:{
+                create: {
                     name: copyValueToObjectIfDefined(args.requestedChange.name),
                     email: copyValueToObjectIfDefined(args.requestedChange.email),
                     avatar: copyValueToObjectIfDefined(args.requestedChange.avatar),
@@ -20,12 +20,13 @@ async function createApproval(_, args, context, info){
                     titleEn: copyValueToObjectIfDefined(args.requestedChange.titleEn),
                     titleFr: copyValueToObjectIfDefined(args.requestedChange.titleFr),
                     team: (args.requestedChange.team) ? {connect: {id: args.requestedChange.team.id}} : null,
+                    ownershipOfTeam: (args.requestedChange.ownershipOfTeam) ? {connect: {id: args.requestedChange.ownershipOfTeam.id}} : null,
                 }
             },
             createdOn: await Date.now().toString(),
             status: "Pending",
             changeType: args.changeType        
-};
+    });
     
     return await context.prisma.mutation.createApproval({
         data
@@ -35,7 +36,7 @@ async function createApproval(_, args, context, info){
 async function appendApproval(_, args, context, info){
     var address = (args.requestedChange.address) ? getNewAddressFromArgs(args.requestedChange) : null;
 
-    const data = {
+    const data = removeNullKeys({
             gcIDApprover: {connect: {gcID: args.gcIDApprover}},
             updatedBy: {connect: {gcID: args.createdBy}},
             requestedChange: {
@@ -49,12 +50,14 @@ async function appendApproval(_, args, context, info){
                     titleEn: copyValueToObjectIfDefined(args.requestedChange.titleEn),
                     titleFr: copyValueToObjectIfDefined(args.requestedChange.titleFr),
                     team: (args.requestedChange.team) ? {connect: {id: args.requestedChange.team.id}} : null,
+                    ownershipOfTeam: (args.requestedChange.ownershipOfTeam) ? {connect: {id: args.requestedChange.ownershipOfTeam.id}} : null,
+                    
                 }
             },
             actionedOn: await Date.now().toString(),
             status: "Pending",
       
-};
+    });
     
     return await context.prisma.mutation.updateApproval({
         where:{
@@ -78,7 +81,7 @@ async function getApprovalChanges(approvalID, context){
         + "titleEn,titleFr,team{id}}}"
     );
     
-    var infoToModify = {
+    var infoToModify = removeNullKeys({
         gcID: approvalToAction.gcIDSubmitter.gcID,
         data: {
             name: copyValueToObjectIfDefined(approvalToAction.requestedChange.name),
@@ -90,7 +93,7 @@ async function getApprovalChanges(approvalID, context){
             titleFr: copyValueToObjectIfDefined(approvalToAction.requestedChange.titleFr)    
         }
 
-    };
+    });
 
     if(approvalToAction.requestedChange.team){
         infoToModify.data.team = {

--- a/src/resolvers/helper/approvalHelper.js
+++ b/src/resolvers/helper/approvalHelper.js
@@ -86,6 +86,7 @@ async function getApprovalChanges(approvalID, context){
     if (approvalToAction.changeType === ("Membership" || "Informational")){
         infoToModify = removeNullKeys({
             gcID: approvalToAction.gcIDSubmitter.gcID,
+            changeType: approvalToAction.changeType,
             data: {
                 name: copyValueToObjectIfDefined(approvalToAction.requestedChange.name),
                 email: copyValueToObjectIfDefined(approvalToAction.requestedChange.email),
@@ -117,6 +118,7 @@ async function getApprovalChanges(approvalID, context){
     if(approvalToAction.changeType === "Team"){
         infoToModify = removeNullKeys({
             id: approvalToAction.requestedChange.ownershipOfTeam.id,
+            changeType: approvalToAction.changeType,
             data: {
                 owner:{
                     gcID: approvalToAction.gcIDApprover.gcID

--- a/src/resolvers/helper/objectHelper.js
+++ b/src/resolvers/helper/objectHelper.js
@@ -21,7 +21,18 @@ const propertyExists = (args, property) => {
 
 function removeNullKeys(object){
   Object.keys(object).forEach((key) => {
-    (!object.key) ? delete object.key : object.key;
+    if (!object[key]){
+      delete object[key];
+      return;
+    }
+    if (object[key] === Object(object[key])){
+      removeNullKeys(object[key]);
+      if(Object.entries(object[key]).length === 0){
+        delete object[key];
+        return;
+      }
+    }
+
   });
   return object;
 }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -220,6 +220,7 @@ enum Status {
 enum ChangeType {
     Membership
     Informational
+    Team
 }
 
 input gcIDProfileInput {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -198,6 +198,7 @@ type RequestedChange {
     titleEn: String
     titleFr: String
     team: Team
+    ownershipOfTeam: Team
 }
 
 input RequestedChangeInput {
@@ -210,6 +211,7 @@ input RequestedChangeInput {
     titleEn: String
     titleFr: String
     team: TeamInput
+    ownershipOfTeam: TeamInput
 }
 
 enum Status {


### PR DESCRIPTION
# Description

The middleware now intercepts modifyTeam mutations and checks to see if there is an ownership change.  If there's a change it creates an approval but passes through all other changes that the owner of the team still has the right to change. 

If the existing owner selects a different person to transfer the team to it amends the existing approval with the new owner instead of creating a new approval.

Once approval is changed to Approve then mutation for team ownership fires.

# Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Transfered existing team to a new supervisor.  Ensured proper approval was created.
- [x] Transferred existing team to a different supervisor. Ensured approval was amended to reflect change.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
