### PR TITLE
Added supervisor relationship permissions

### DIFF
--- a/src/Middleware/profileApprovalCreation.js
+++ b/src/Middleware/profileApprovalCreation.js
@@ -72,13 +72,14 @@ async function getNewSupervisor(context, gcID){
 }
 
 async function isAllowedSupervisor(context, requestedChanges){
+    // Check for self reporting relationship
     if(requestedChanges.approvalSubmitter === requestedChanges.approverID.gcID){
         throw new AuthenticationError("A supervisor must be a different person than the selected user");
     }
 
     const approver = await getProfile(context, requestedChanges.approverID);
-    console.log(approver);
 
+    // Check for circular relationship with team member
     if(approver.team.owner && approver.team.owner.gcID == requestedChanges.approvalSubmitter) {
         throw new AuthenticationError("Selected supervisor is already member of user's team");
     }
@@ -190,6 +191,7 @@ const profileApprovalRequired = async (resolve, root, args, context, info) => {
         return await resolve(root, args, context, info);
     }
 
+    // See if there is a team change and if it is allowed relationship
     await isAllowedSupervisor(context, requestedChanges);
 
     for (var field in args.data){

--- a/src/Middleware/profileApprovalCreation.js
+++ b/src/Middleware/profileApprovalCreation.js
@@ -106,6 +106,9 @@ async function generateMemerbshipApproval(membershipChanges, context, approvals 
         // Get memebership approval if it exists
         const approval = await getApprovalType(approvals, "Membership");
 
+        // See if there is a team change and if it is allowed relationship
+        await isAllowedSupervisor(context, membershipChanges);
+
         var teamApprovalObject = {
             gcIDApprover: membershipChanges.approverID.gcID,
             gcIDSubmitter: membershipChanges.approvalSubmitter,
@@ -190,9 +193,6 @@ const profileApprovalRequired = async (resolve, root, args, context, info) => {
         // it's a membership change
         return await resolve(root, args, context, info);
     }
-
-    // See if there is a team change and if it is allowed relationship
-    await isAllowedSupervisor(context, requestedChanges);
 
     for (var field in args.data){
         // Find any fields wrapped with the @requiresApproval directive and

--- a/src/Middleware/profileApprovalCreation.js
+++ b/src/Middleware/profileApprovalCreation.js
@@ -204,7 +204,7 @@ const profileApprovalRequired = async (resolve, root, args, context, info) => {
     }
     
     // If the supervisor is changing a persons team pass through the changes
-    if(requestedChanges.data.team && requestedChanges.approverID.gcID === context.token.owner.gcID){
+    if(requestedChanges.data.team && submitter.team.owner && submitter.team.owner.gcID === context.token.owner.gcID){
         const teamArgs = {
             gcID: args.gcID,
             data:{

--- a/src/Middleware/profileApprovalCreation.js
+++ b/src/Middleware/profileApprovalCreation.js
@@ -80,7 +80,7 @@ async function isAllowedSupervisor(context, requestedChanges){
     const approver = await getProfile(context, requestedChanges.approverID);
 
     // Check for circular relationship with team member
-    if(approver.team.owner && approver.team.owner.gcID == requestedChanges.approvalSubmitter) {
+    if(approver.team.owner && approver.team.owner.gcID === requestedChanges.approvalSubmitter) {
         throw new AuthenticationError("Selected supervisor is already member of user's team");
     }
 }


### PR DESCRIPTION
# Description

Added supervisor permissions approval middleware. User's can no longer create a self report relationship or a circular relationship with a member of their team in the role of supervisor.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tests were done using the directory-fe

## Self report relationship 

- [x] As member of team, used the change supervisor modal to try and set self as supervisor. Received appropriate error message.
- [x] As supervisor, tried to change a member of my team's supervisor to same user. Received appropriate error message.

## Circular relationship 

- [x] As supervisor, tired to change my supervisor to someone in my team. Received appropriate error message.
- [x] As supervisor of user, tried to change a member of my team's supervisor to user in their team. Received appropriate error message.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
