### PR TITLE
Account seeder script

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "ejs": "^2.6.2",
     "eslint": "^5.14.1",
     "express-jwt": "^5.3.1",
+    "got": "^10.7.0",
     "graphql": "^14.1.1",
     "graphql-binding": "^2.5.0",
     "graphql-middleware": "^3.0.2",

--- a/scripts/accounts_seeder.js
+++ b/scripts/accounts_seeder.js
@@ -1,7 +1,6 @@
 const config = require("../src/config");
 const { Prisma } = require("prisma-binding");
 const got = require('got');
-const { GraphQLError } = require("graphql");
 const { createProfile } = require("../src/Resolvers/Mutations");
 const { getDefaults } = require("../src/Resolvers/helper/default_setup");
 
@@ -19,9 +18,9 @@ async function account_seeder() {
 
     const accounts = await got(config.openId.url + '/api/users/all', {});
 
-    console.log(JSON.parse(accounts.body));
-
     var profiles = JSON.parse(accounts.body);
+
+    console.log("Found " + profiles.length + " accounts")
 
     for (var u = 0; u < profiles.length; u++) {
         var args = {

--- a/scripts/accounts_seeder.js
+++ b/scripts/accounts_seeder.js
@@ -1,0 +1,41 @@
+const config = require("../src/config");
+const { Prisma } = require("prisma-binding");
+const got = require('got');
+const { GraphQLError } = require("graphql");
+const { createProfile } = require("../src/Resolvers/Mutations");
+const { getDefaults } = require("../src/Resolvers/helper/default_setup");
+
+const ctx = {
+    prisma: new Prisma({
+        typeDefs: "./src/generated/prisma.graphql",
+        endpoint: "http://" + config.prisma.host + ":4466/profile/",
+        debug: config.prisma.debug,
+    })
+};
+
+async function account_seeder() {
+
+    ctx.defaults = await getDefaults();
+
+    const accounts = await got(config.openId.url + '/api/users/all', {});
+
+    console.log(JSON.parse(accounts.body));
+
+    var profiles = JSON.parse(accounts.body);
+
+    for (var u = 0; u < profiles.length; u++) {
+        var args = {
+            gcID: profiles[u].id,
+            name: profiles[u].name,
+            email: profiles[u].email
+        };
+        try {
+            await createProfile(null, args, ctx, "{gcID, name, email}");
+        } catch (e) {
+            console.error(e);
+        }
+    }
+}
+
+
+account_seeder();


### PR DESCRIPTION
# Description

Script to hit GCaccount to get users and generate profiles for them. 
Requires account service with this PR https://github.com/gctools-outilsgc/concierge/pull/161

Make sure to run npm install to install got.

# Type of change

New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- With a configured fresh install of PaaS run 'node scripts/accounts_seeder.js username "password"' to generate profiles using administrator credentials.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
