### PR TITLE
add e to globale

### DIFF
--- a/src/Resolvers/helper/default_setup.js
+++ b/src/Resolvers/helper/default_setup.js
@@ -27,7 +27,7 @@ async function createDefaultOrg() {
             teams:{
                 create:{
                     nameEn:"Global Team",
-                    nameFr:"Équipe Global"
+                    nameFr:"Équipe Globale"
                 }
             }
         }


### PR DESCRIPTION
# Description

In the default script, global team is create in both language. But in french, we need to add an "e" at the end of global because équipe (team) is female.

Fixes https://zube.io/tbs-sct/gctools/c/5947

