### PR TITLE
Added isAdmin to profile + admin rights

### DIFF
--- a/prisma/datamodel.graphql
+++ b/prisma/datamodel.graphql
@@ -14,6 +14,7 @@ type Profile {
   submittedApprovals: [Approval] @relation(name:"Submitter", onDelete: CASCADE)
   createdApprovals: [Approval] @relation(name:"Creator")
   updatedApprovals: [Approval] @relation(name:"Updater")
+  isAdmin: Boolean!
 }
 
 type Address {

--- a/src/Auth/introspection.js
+++ b/src/Auth/introspection.js
@@ -3,35 +3,35 @@ const config = require("../config");
 const { Prisma } = require("prisma-binding");
 const { throwExceptionIfProfileIsNotDefined } = require("../Resolvers/helper/profileHelper");
 
-async function getTokenOwner(tokenData){
+async function getTokenOwner(tokenData) {
 
   const prisma = await new Prisma({
     typeDefs: "./src/generated/prisma.graphql",
-    endpoint: "http://"+config.prisma.host+":4466/profile/",
+    endpoint: "http://" + config.prisma.host + ":4466/profile/",
     debug: config.prisma.debug,
   });
 
   try {
     tokenData.owner = await prisma.query.profile(
       {
-          where: {
-              gcID: tokenData.sub
-          }            
-      },"{gcID, name, email, team{id, owner{gcID}, organization{id}}}");
-  } catch(e){
+        where: {
+          gcID: tokenData.sub
+        }
+      }, "{gcID, name, email, isAdmin, team{id, owner{gcID}, organization{id}}}");
+  } catch (e) {
     throw new Error("Profile does not exist");
   }
-    await throwExceptionIfProfileIsNotDefined(tokenData.owner);
-    return tokenData;
+  await throwExceptionIfProfileIsNotDefined(tokenData.owner);
+  return tokenData;
 }
 
-async function verifyToken(request){
+async function verifyToken(request) {
 
   var token;
   var tokenData;
 
   //see if token provided in request
-  if(await request.req.headers.hasOwnProperty("authorization")){
+  if (await request.req.headers.hasOwnProperty("authorization")) {
     //remove "bearer" from token
     var splitReq = request.req.headers.authorization.split(" ");
     token = splitReq[1];
@@ -54,19 +54,19 @@ async function verifyToken(request){
   };
 
   await fetch(url, postOptions)
-  .then((response) => response.json())
-  .then(function(data){ 
-    tokenData = data;
-  })
-  .catch((error) => {
-    const errorMsg = {
-      "active": false,
-      "message": error.message
-    };
-    tokenData = errorMsg;
-  });
+    .then((response) => response.json())
+    .then(function (data) {
+      tokenData = data;
+    })
+    .catch((error) => {
+      const errorMsg = {
+        "active": false,
+        "message": error.message
+      };
+      tokenData = errorMsg;
+    });
 
-  if (tokenData.active){
+  if (tokenData.active) {
     tokenData = await getTokenOwner(tokenData);
   }
 

--- a/src/Middleware/profileApprovalCreation.js
+++ b/src/Middleware/profileApprovalCreation.js
@@ -2,7 +2,7 @@ const { AuthenticationError } = require("apollo-server");
 const { createApproval, appendApproval } = require("../Resolvers/helper/approvalHelper");
 const { removeNullKeys, cloneObject } = require("../Resolvers/helper/objectHelper");
 const { getProfile, checkForDirective, checkForEmptyChanges, getApprovalType, getExistingApprovals } = require("./common");
-const {modifyApproval} = require("../Resolvers/Mutations");
+const { modifyApproval } = require("../Resolvers/Mutations");
 
 /*-------------------------------------------------------------------------
 User submits changes with both memembership and Informational
@@ -10,26 +10,26 @@ User submits changes with both memembership and Informational
  - New supervisor cannot approve information until membership approved
  - Denying membership also cancels the associated informational change
 --------------------------------------------------------------------------*/
-async function noNewSupervisor(context, submitter){
+async function noNewSupervisor(context, submitter) {
     const approval = await getExistingApprovals(context, submitter.gcID)
-    .then(async (approvals) => {
-        return await getApprovalType(approvals, "Informational");
-    });
+        .then(async (approvals) => {
+            return await getApprovalType(approvals, "Informational");
+        });
 
-    if (approval){
-        modifyApproval(null, {id: approval.id, data:{status:"Approved"}}, context);
+    if (approval) {
+        modifyApproval(null, { id: approval.id, data: { status: "Approved" } }, context);
     }
 
 }
 
-async function isThereATeamOwner(teamID, context){
-    
-    if(!teamID){
+async function isThereATeamOwner(teamID, context) {
+
+    if (!teamID) {
         return null;
     }
 
     const owner = await context.prisma.query.team({
-        where:{
+        where: {
             id: teamID.id
         }
     }, "{owner{gcID, name}}");
@@ -41,7 +41,7 @@ async function isThereATeamOwner(teamID, context){
 async function checkAgainstExistingApprovals(requestedChanges, approvals) {
 
     // If there are no existing approvals then short circuit
-    if (!approvals.length){
+    if (!approvals.length) {
         return null;
     }
 
@@ -49,11 +49,11 @@ async function checkAgainstExistingApprovals(requestedChanges, approvals) {
     await Promise.all(approvals.map((approval) => {
         removeNullKeys(approval.requestedChange);
     }));
-    
+
     // If the field is already covered by an existing Approval then ignore it
     await Promise.all(approvals.map(async (approval) => {
         Object.keys(requestedChanges).forEach((field) => {
-            if (approval.requestedChange.field && field === approval.requestedChange.field){
+            if (approval.requestedChange.field && field === approval.requestedChange.field) {
                 delete requestedChanges.field;
             }
         });
@@ -62,41 +62,41 @@ async function checkAgainstExistingApprovals(requestedChanges, approvals) {
     return approvals;
 }
 
-async function checkAgainstExistingProfile(requestedChanges, submitterProfile){
+async function checkAgainstExistingProfile(requestedChanges, submitterProfile) {
     await Object.keys(submitterProfile).forEach((field) => {
-        if (requestedChanges[field] === submitterProfile[field]){
+        if (requestedChanges[field] === submitterProfile[field]) {
             delete requestedChanges[field];
         }
     });
 }
 
-async function getNewSupervisor(context, gcID){
+async function getNewSupervisor(context, gcID) {
     return await getExistingApprovals(context, gcID)
-    .then((approvals) => {
-        return getApprovalType(approvals, "Membership");
-    })
-    .then((membershipApproval) => {
-        if (membershipApproval){
-            return isThereATeamOwner(membershipApproval.requestedChange.team, context);
-        }
-        return null;
-    });
+        .then((approvals) => {
+            return getApprovalType(approvals, "Membership");
+        })
+        .then((membershipApproval) => {
+            if (membershipApproval) {
+                return isThereATeamOwner(membershipApproval.requestedChange.team, context);
+            }
+            return null;
+        });
 }
 
 async function checkChildNodes(context, approver, parent) {
 
     var childNodes = await context.prisma.query.profile({
-            where: {
-                gcID: parent
-            }
-        }, "{ownerOfTeams{members{gcID}}}");
+        where: {
+            gcID: parent
+        }
+    }, "{ownerOfTeams{members{gcID}}}");
 
 
-    if (childNodes.ownerOfTeams.length > 0){
+    if (childNodes.ownerOfTeams.length > 0) {
         await Promise.all(childNodes.ownerOfTeams.map(async (team) => {
-            if (team.members.length > 0){
+            if (team.members.length > 0) {
                 await Promise.all(team.members.map(async (member) => {
-                    if (member.gcID === approver.gcID){
+                    if (member.gcID === approver.gcID) {
                         throw new Error("Circular relationship caught");
                     } else {
                         await checkChildNodes(context, approver, member.gcID);
@@ -105,14 +105,14 @@ async function checkChildNodes(context, approver, parent) {
                 }));
             }
             return;
-        }));        
+        }));
     }
-    return; 
+    return;
 }
 
-async function isAllowedSupervisor(context, requestedChanges){
+async function isAllowedSupervisor(context, requestedChanges) {
     // Check for self reporting relationship
-    if(requestedChanges.approvalSubmitter === requestedChanges.approverID.gcID){
+    if (requestedChanges.approvalSubmitter === requestedChanges.approverID.gcID) {
         throw new AuthenticationError("A supervisor must be a different person than the selected user");
     }
 
@@ -121,28 +121,28 @@ async function isAllowedSupervisor(context, requestedChanges){
     // Take requester and scan through child nodes for matching gcID.
 
     await checkChildNodes(context, requestedChanges.approverID, requestedChanges.approvalSubmitter)
-    .catch(() => {
-        throw new AuthenticationError("Selected supervisor would create a circular reporting relationship");
-    });
+        .catch(() => {
+            throw new AuthenticationError("Selected supervisor would create a circular reporting relationship");
+        });
 
 }
 
-async function whoIsTheApprover(context, args, submitterProfile){
+async function whoIsTheApprover(context, args, submitterProfile) {
     const newTeamOwner = await isThereATeamOwner(args.data.team, context);
     const membershipRequest = await getNewSupervisor(context, args.gcID);
 
-    if (args.data.team){
+    if (args.data.team) {
         return (newTeamOwner) ? newTeamOwner.owner : null;
     }
     if (membershipRequest && submitterProfile.team.owner) {
         return membershipRequest.owner;
-    }            
+    }
     return (submitterProfile.team.owner) ? submitterProfile.team.owner : null;
-    
+
 }
 
-async function generateMemerbshipApproval(membershipChanges, context, approvals = null){
-    if (membershipChanges.data.team){
+async function generateMemerbshipApproval(membershipChanges, context, approvals = null) {
+    if (membershipChanges.data.team) {
 
         // Get memebership approval if it exists
         const approval = await getApprovalType(approvals, "Membership");
@@ -155,7 +155,7 @@ async function generateMemerbshipApproval(membershipChanges, context, approvals 
             gcIDSubmitter: membershipChanges.approvalSubmitter,
             createdBy: membershipChanges.createdBy,
             requestedChange: {
-                team:{
+                team: {
                     id: membershipChanges.data.team.id
                 }
             },
@@ -163,31 +163,31 @@ async function generateMemerbshipApproval(membershipChanges, context, approvals 
 
         };
 
-        if(approval){
+        if (approval) {
             teamApprovalObject.id = approval.id;
             await appendApproval(null, teamApprovalObject, context)
-            .catch((e) => {
-                // eslint-disable-next-line no-console
-                console.log(e);
-            });
+                .catch((e) => {
+                    // eslint-disable-next-line no-console
+                    console.log(e);
+                });
         } else {
             await createApproval(null, teamApprovalObject, context)
-            .catch((e) => {
-            // eslint-disable-next-line no-console
-            console.log(e);
-            });
+                .catch((e) => {
+                    // eslint-disable-next-line no-console
+                    console.log(e);
+                });
         }
     }
     return;
 }
 
-async function generateInformationalApproval(informationalChanges, context, approvals = null){
+async function generateInformationalApproval(informationalChanges, context, approvals = null) {
     // Remove team object because it's being handled in Membership chang
-    if (informationalChanges.data.team){
-            delete informationalChanges.data.team;
-        }
+    if (informationalChanges.data.team) {
+        delete informationalChanges.data.team;
+    }
     // If no current supervisor don't create an approval object
-    if(context.submitter.team.owner){
+    if (context.submitter.team.owner) {
 
         const approval = await getApprovalType(approvals, "Informational");
 
@@ -199,23 +199,23 @@ async function generateInformationalApproval(informationalChanges, context, appr
             changeType: "Informational"
         };
 
-        if(approval){
+        if (approval) {
             informationalApprovalObject.id = approval.id;
             await appendApproval(null, informationalApprovalObject, context)
-            .catch((e) => {
-                // eslint-disable-next-line no-console
-                console.error(e);
-            });
-        } else {
-            if(!checkForEmptyChanges(informationalApprovalObject.requestedChange)){
-                await createApproval(null, informationalApprovalObject, context)
                 .catch((e) => {
                     // eslint-disable-next-line no-console
                     console.error(e);
                 });
-            } 
+        } else {
+            if (!checkForEmptyChanges(informationalApprovalObject.requestedChange)) {
+                await createApproval(null, informationalApprovalObject, context)
+                    .catch((e) => {
+                        // eslint-disable-next-line no-console
+                        console.error(e);
+                    });
+            }
         }
-    }    
+    }
     return;
 }
 
@@ -229,36 +229,36 @@ const profileApprovalRequired = async (resolve, root, args, context, info) => {
     requestedChanges.approvalSubmitter = context.submitter.gcID;
     requestedChanges.approverID = await whoIsTheApprover(context, args, context.submitter);
 
-    if (!requestedChanges.approverID){
+    if (!requestedChanges.approverID || context.token.owner.isAdmin) {
         // If no current supervisor or moving to organization default team 
         // then pass through changes unless it's a membership change with a supervisor
 
         // If existing approval for Informational change auto-approve 
         // because there is no new supervisor to approve
-        
-        noNewSupervisor(context, {gcID: context.submitter.gcID});
+
+        noNewSupervisor(context, { gcID: context.submitter.gcID });
         return await resolve(root, args, context, info);
     }
 
-    for (var field in args.data){
+    for (var field in args.data) {
         // Find any fields wrapped with the @requiresApproval directive and
         // remove them from the current context
-        if (await checkForDirective(field, info, "requiresApproval")){
+        if (await checkForDirective(field, info, "requiresApproval")) {
             requestedChanges.data[field] = args.data[field];
             delete args.data[field];
         }
     }
-    
+
     // If the supervisor is changing a persons team pass through the changes
-    if(requestedChanges.data.team && context.submitter.team.owner && context.submitter.team.owner.gcID === context.token.owner.gcID){
+    if (requestedChanges.data.team && context.submitter.team.owner && context.submitter.team.owner.gcID === context.token.owner.gcID) {
         const teamArgs = {
             gcID: args.gcID,
-            data:{
-                team:{
+            data: {
+                team: {
                     id: requestedChanges.data.team.id
                 }
             }
-            
+
         };
         return await resolve(root, teamArgs, context, info);
     }
@@ -272,24 +272,24 @@ const profileApprovalRequired = async (resolve, root, args, context, info) => {
     // approvals generated for the change
 
     const existingApprovals = await getExistingApprovals(context, requestedChanges.approvalSubmitter)
-    .then((approvals) => checkAgainstExistingApprovals(requestedChanges.data, approvals));
+        .then((approvals) => checkAgainstExistingApprovals(requestedChanges.data, approvals));
 
     // If there are still changes in the requestedChanges object that were not
     // filtered out by the existing profile or existing approvals then create
     // or append existing approvals.
 
-    if(!checkForEmptyChanges(requestedChanges.data)){
+    if (!checkForEmptyChanges(requestedChanges.data)) {
         await Promise.all(
             [
                 generateMemerbshipApproval(cloneObject(requestedChanges), context, existingApprovals),
                 generateInformationalApproval(cloneObject(requestedChanges), context, existingApprovals)
             ]);
-    }  
+    }
 
     // mutate any remainng non protected fields and resolve info
-    return await resolve(root, args, context, info);  
+    return await resolve(root, args, context, info);
 };
 
-module.exports ={
+module.exports = {
     profileApprovalRequired
 };

--- a/src/Resolvers/Mutations.js
+++ b/src/Resolvers/Mutations.js
@@ -26,7 +26,8 @@ async function createProfile(_, args, context, info) {
         team: {
             connect: { id: context.defaults.org.teams[0].id }
 
-        }
+        },
+        isAdmin: args.isAdmin
     };
 
     if (propertyExists(args, "avatar")) {
@@ -58,7 +59,6 @@ async function createProfile(_, args, context, info) {
         createProfileData.ownerOfTeams.create.organization.connect.id = teamInfo.organization.id;
     }
 
-
     const profile = await context.prisma.mutation.createProfile({
         data: createProfileData,
     }, info);
@@ -89,6 +89,7 @@ async function modifyProfile(_, args, context, info) {
         officePhone: copyValueToObjectIfDefined(args.data.officePhone),
         titleEn: copyValueToObjectIfDefined(args.data.titleEn),
         titleFr: copyValueToObjectIfDefined(args.data.titleFr),
+        isAdmin: copyValueToObjectIfDefined(args.data.isAdmin),
     };
 
     if (propertyExists(args.data, "avatar")) {
@@ -155,8 +156,8 @@ async function deleteProfile(_, args, context) {
 
 
 
-function createOrganization(_, args, context, info) {
-    return context.prisma.mutation.createOrganization({
+async function createOrganization(_, args, context, info) {
+    return await context.prisma.mutation.createOrganization({
         data: {
             nameEn: args.nameEn,
             nameFr: args.nameFr,

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -8,6 +8,8 @@ directive @inOrganization on FIELD_DEFINITION
 # The access token passed must be valid in order to proceed.
 directive @isAuthenticated on OBJECT | FIELD_DEFINITION
 
+directive @onlyAdmin on FIELD_DEFINITION
+
 # The @isSameTeam directive can be placed on a field of a Profile object and will only
 # return the field value if the requestor is on the same team
 directive @isSameTeam on FIELD_DEFINITION
@@ -53,9 +55,9 @@ type Mutation {
   deleteTeam(id: ID!): Boolean!
 
 # The Organization mutations are being removed because they would be Admin type mutations
-# createOrganization(nameEn: String!, nameFr: String!, acronymEn: String!, acronymFr: String!): Organization!
-# modifyOrganization(id: ID!, data: ModifyOrganizationInput): Organization!
-# deleteOrganization(id: ID!): Boolean!
+  createOrganization(nameEn: String!, nameFr: String!, acronymEn: String!, acronymFr: String!): Organization!
+  modifyOrganization(id: ID!, data: ModifyOrganizationInput): Organization!
+  deleteOrganization(id: ID!): Boolean!
   
   modifyApproval(id: ID!, data: ModifyApprovalInput): Approval! @isAuthenticated
 }
@@ -80,6 +82,7 @@ type Profile {
   ownerOfTeams: [Team!]!
   outstandingApprovals: [Approval!]!
   submittedApprovals: [Approval!]!
+  isAdmin: Boolean! @onlyAdmin
 }
 
 type Address {
@@ -150,6 +153,7 @@ input ModifyProfileInput {
   titleEn: String 
   titleFr: String 
   team: TeamInput 
+  isAdmin: Boolean
 }
 
 input ModifyTeamInput {


### PR DESCRIPTION
# Description

Added isAdmin to Profile. Users that have isAdmin: true are able to edit other user's information.
Also added mutations related to organizations back to the schema. Only Admin users are able to run them.

Relies on https://github.com/gctools-outilsgc/concierge/pull/169

# Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Using GraphQL Playground
- [x] Using token from non-admin user try and run a modifyProfile mutation on a different user. Will receive an error when attempting to run mutation.
- [x] Using token from admin user run a modifyProfile mutation on a different user. Mutation should go through normally and bypass approval logic.

- [x] Using token from non-admin user, try and run a createOrganization mutation. Will receive an error when attempting to run mutation.
- [x] Using token from admin user run a createOrganization mutation. Mutation should go through normally.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
