### PR TITLE
Add ability to search by email,  phone number, team and depart

### DIFF
--- a/scripts/search_seeder.js
+++ b/scripts/search_seeder.js
@@ -40,7 +40,7 @@ async function seed(){
     // Get all profile information needed into a single JSON.
     var info = `query queryProfiles {
         profiles { gcID, name, email, mobilePhone, officePhone, titleEn, titleFr,
-        team{nameEn, nameFr, organization{nameEn, nameFr, acronymEn, acronymFr}}}
+        team{id, nameEn, nameFr, organization{id, nameEn, nameFr}}}
       }`;
     const users = await graphql(schema, info);
     const profiles = users.data.profiles;

--- a/src/Search/transformer.js
+++ b/src/Search/transformer.js
@@ -1,18 +1,50 @@
 const { publishMessageQueue } = require("../Service_Mesh/publisher_connector");
 
-function suggester(field){
-    var suggestions = field.split(" ");
-    suggestions.push(field);
+function suggester(newProfile, newTeam, newOrg){
+    // add to the suggester field
+    var suggestions = newProfile.name.split(" ");
+    suggestions.push(newProfile.name);
+    suggestions.push(newProfile.email);
+    newProfile.mobilePhone != '' ? suggestions.push(newProfile.mobilePhone) : "";
+    newProfile.officePhone != '' ? suggestions.push(newProfile.officePhone) : "";
+    if(typeof newTeam !== 'undefined'){
+        suggestions.push(newTeam.nameFr)
+        suggestions.push(newTeam.nameEn)
+    }
+
+    if(typeof newOrg !== 'undefined'){
+        suggestions.push(newOrg.nameFr)
+        suggestions.push(newOrg.nameEn)
+    }
     return suggestions;
 }
 
 async function searchPrep(profile, action, context){
+//add profile, team and organization info to the suggester
     var newProfile = await context.prisma.query.profile({
         where:{
             gcID: profile.gcID
         }
     });
-    newProfile.suggest = await suggester(newProfile.name);
+
+    if(profile.team !== null){
+        var newTeam = await context.prisma.query.team({
+            where:{
+                id: profile.team.id
+            }
+        });
+
+        var newOrg = await context.prisma.query.organization({
+            where:{
+                id: profile.team.organization.id
+            }
+        });   
+    }else{
+       var newTeam = "";
+       var newOrg = "";       
+    }
+
+    newProfile.suggest = await suggester(newProfile, newTeam, newOrg);
     publishMessageQueue("profile", "profile." + action, newProfile)
     .catch((e) => {
         // Need to implement error handling


### PR DESCRIPTION
# Description

Add the ability to search by email, phone number, team name (english and french) and department name (english and french).

Fixes # https://zube.io/tbs-sct/gctools/c/5896
Link to https://github.com/gctools-outilsgc/search_engine/pull/1

# Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Before starting, you need to make sure that in the mapping of the search engine, the analyzer of suggester field is set to standard. Once this is done, you can run the search_seeder script. After, try to search using a phone number, an email, a team name and an organization name in the language of you choice.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
