### PR TITLE
Add user.modification handler

### DIFF
--- a/src/Service_Mesh/handler.js
+++ b/src/Service_Mesh/handler.js
@@ -1,6 +1,6 @@
 // Handler for messages from different exchanges and keys
 const { Prisma } = require("prisma-binding");
-const { createProfile } = require("../Resolvers/Mutations");
+const { createProfile, modifyProfile } = require("../Resolvers/Mutations");
 const { GraphQLError } = require("graphql");
 const { publishMessageQueue } = require("./publisher_connector");
 const config = require("../config");
@@ -36,6 +36,39 @@ async function msgHandler(msg, success) {
                     };
                     try {
                         await publishMessageQueue("errors", "profile.creation", rejectMsg);
+                    } catch (err) {
+                        // eslint-disable-next-line no-console
+                        console.error(err);
+                    }
+                    // The error has been handled and no longer need to be in queue
+                    success(true);
+
+
+                } else {
+                    // If it's not a GraphQL Error then requeue it.
+                    success(false);
+                }
+            }
+            break;
+        case "user.modification":
+            var args = {
+                gcID: messageBody.gcID,
+                data: {
+                    name: messageBody.name,
+                    email: messageBody.email,
+                },
+            };
+            try {
+                await modifyProfile(null, args, context, "{gcID, name, email}");
+                success(true);
+            } catch (err) {
+                if (err instanceof GraphQLError) {
+                    let rejectMsg = {
+                        args,
+                        error: err
+                    };
+                    try {
+                        await publishMessageQueue("errors", "profile.modification", rejectMsg);
                     } catch (err) {
                         // eslint-disable-next-line no-console
                         console.error(err);


### PR DESCRIPTION
# Description

When a user or an admin modifies a user's name or email on account, the changes will be passed to PaaS to keep the information synced.  

# How Has This Been Tested?

Using this branch on concierge https://github.com/gctools-outilsgc/concierge/pull/176

- [ ] Modify name or email on concierge, refresh profile to see new information has been updated.

