### PR TITLE
add orgtype and isadmin to script

### DIFF
--- a/scripts/profile_seeder.js
+++ b/scripts/profile_seeder.js
@@ -21,6 +21,8 @@ async function seed(){
     // Number or profiles to create in each Organization
     const profileNumber = 4000;
 
+    const orgList = ["Default", "Federal", "Provincial", "Municipal", "University", "College", "Other"]; 
+
     try {
         // Create n organizations
         for(var o = 0; o < orgNumber; o++){
@@ -38,6 +40,7 @@ async function seed(){
                     nameFr: orgFr,
                     acronymEn: faker.hacker.abbreviation(),
                     acronymFr: faker.hacker.abbreviation(),
+                    orgType:orgList[Math.floor(Math.random() * orgList.length)]
                 };
 
                 // Store the created org info to assign teams to the org.
@@ -67,6 +70,7 @@ async function seed(){
                             officePhone: faker.phone.phoneNumberFormat(),
                             titleEn: faker.name.jobType(),
                             titleFr: faker.name.jobType(), 
+                            isAdmin: false,
                             address: { 
                                 create :{
                                     streetAddress: faker.address.streetAddress(),


### PR DESCRIPTION
# Description

Adding OrgType value and isAdmin to profile script.

Fixes # https://zube.io/tbs-sct/gctools/c/6279

# Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

On an empty instance, run the profile_seeder script

