### PR TITLE
Update admin function

### DIFF
--- a/prisma/datamodel.graphql
+++ b/prisma/datamodel.graphql
@@ -14,7 +14,7 @@ type Profile {
   submittedApprovals: [Approval] @relation(name:"Submitter", onDelete: CASCADE)
   createdApprovals: [Approval] @relation(name:"Creator")
   updatedApprovals: [Approval] @relation(name:"Updater")
-  isAdmin: Boolean!
+  role: UserRole!
 }
 
 type Address {
@@ -101,4 +101,9 @@ enum OrgType {
     University
     College
     Other
+}
+
+enum UserRole {
+    User
+    Admin
 }

--- a/scripts/accounts_seeder.js
+++ b/scripts/accounts_seeder.js
@@ -52,7 +52,8 @@ async function account_seeder() {
         var args = {
             gcID: profiles[u].id,
             name: profiles[u].name,
-            email: profiles[u].email
+            email: profiles[u].email,
+            role: (profiles[u].isAdmin) ? "Admin" : "User"
         };
         try {
             await createProfile(null, args, ctx, "{gcID, name, email}");

--- a/scripts/profile_seeder.js
+++ b/scripts/profile_seeder.js
@@ -70,7 +70,7 @@ async function seed(){
                             officePhone: faker.phone.phoneNumberFormat(),
                             titleEn: faker.name.jobType(),
                             titleFr: faker.name.jobType(), 
-                            isAdmin: false,
+                            role: "User",
                             address: { 
                                 create :{
                                     streetAddress: faker.address.streetAddress(),

--- a/src/Auth/Directives.js
+++ b/src/Auth/Directives.js
@@ -9,7 +9,7 @@ const { blockValue, getOrganizationid, getTeamid, getSupervisorid, getOwnerid } 
   These fragments will ensure that the fields that are required to identify relationships for access
   levels will always be returned.
 */
-const profileFragment = "fragment authProfile on Profile {gcID, name, email, isAdmin, team{id, owner{gcID}, organization{id}}}";
+const profileFragment = "fragment authProfile on Profile {gcID, name, email, role, team{id, owner{gcID}, organization{id}}}";
 
 
 // inOrganization directive can only be used on the Profile object fields.

--- a/src/Auth/introspection.js
+++ b/src/Auth/introspection.js
@@ -17,7 +17,7 @@ async function getTokenOwner(tokenData) {
         where: {
           gcID: tokenData.sub
         }
-      }, "{gcID, name, email, isAdmin, team{id, owner{gcID}, organization{id}}}");
+      }, "{gcID, name, email, role, team{id, owner{gcID}, organization{id}}}");
   } catch (e) {
     throw new Error("E8TokenProfileNotExist");
   }

--- a/src/Middleware/authMiddleware.js
+++ b/src/Middleware/authMiddleware.js
@@ -8,7 +8,7 @@ const allowedToModifyProfile = async (resolve, root, args, context, info) => {
     // Only the profile owner or their current supervisor can modify a profile
 
     const submitter = await getProfile(context, args);
-    if (args.gcID !== context.token.owner.gcID && (submitter.team.owner === null || context.token.owner.gcID !== submitter.team.owner.gcID) && !context.token.owner.isAdmin) {
+    if (args.gcID !== context.token.owner.gcID && (submitter.team.owner === null || context.token.owner.gcID !== submitter.team.owner.gcID) && context.token.owner.role !== "Admin") {
         throw new AuthenticationError("E10MustBeOwnerOrSupervisor");
     }
     return await resolve(root, args, context, info);
@@ -18,7 +18,7 @@ const allowedToModifyProfile = async (resolve, root, args, context, info) => {
 const allowedToModifyTeam = async (resolve, root, args, context, info) => {
     // Only the current team owner can modify a team
     const existingTeam = await getTeam(context, args.id);
-    if (existingTeam.owner.gcID !== context.token.owner.gcID && !context.token.owner.isAdmin) {
+    if (existingTeam.owner.gcID !== context.token.owner.gcID && context.token.owner.role !== "Admin") {
         throw new AuthenticationError("E11MustBeTeamOwner");
     }
     return await resolve(root, args, context, info);
@@ -90,7 +90,7 @@ const mustBeAdmin = async (resolve, root, args, context, info) => {
 
     // Must be an admin
 
-    if (!context.token || !context.token.owner.isAdmin) {
+    if (!context.token || context.token.owner.role !== "Admin") {
         throw new AuthenticationError("Must be an system admin");
     }
     return await resolve(root, args, context, info);
@@ -101,7 +101,7 @@ const adminOnlyField = async (resolve, root, args, context, info) => {
 
     for (var field in args.data) {
         if (await checkForDirective(field, info, "onlyAdmin")) {
-            if (!context.token.owner.isAdmin) {
+            if (context.token.owner.role !== "Admin") {
                 delete args.data[field];
             }
         }

--- a/src/Middleware/profileApprovalCreation.js
+++ b/src/Middleware/profileApprovalCreation.js
@@ -229,7 +229,7 @@ const profileApprovalRequired = async (resolve, root, args, context, info) => {
     requestedChanges.approvalSubmitter = context.submitter.gcID;
     requestedChanges.approverID = await whoIsTheApprover(context, args, context.submitter);
 
-    if (!requestedChanges.approverID || context.token.owner.isAdmin) {
+    if (!requestedChanges.approverID || context.token.owner.role == "Admin") {
         // If no current supervisor or moving to organization default team 
         // then pass through changes unless it's a membership change with a supervisor
 

--- a/src/Middleware/teamApprovalCreation.js
+++ b/src/Middleware/teamApprovalCreation.js
@@ -49,7 +49,7 @@ const teamApprovalRequired = async (resolve, root, args, context, info) => {
 
     const existingTeam = await getTeam(context, args.id);
 
-    if (args.data.owner && args.data.owner.gcID !== existingTeam.owner.gcID && !context.token.owner.isAdmin) {
+    if (args.data.owner && args.data.owner.gcID !== existingTeam.owner.gcID && context.token.owner.role !== "Admin") {
         // change in ownership
         // clone args object so we don't need to wait for generate team transfer to return.
         generateTeamTransferApproval(context, existingTeam, cloneObject(args.data.owner));

--- a/src/Resolvers/Mutations.js
+++ b/src/Resolvers/Mutations.js
@@ -27,7 +27,7 @@ async function createProfile(_, args, context, info) {
             connect: { id: context.defaults.org.teams[0].id }
 
         },
-        isAdmin: args.isAdmin
+        role: args.role
     };
 
     if (propertyExists(args, "avatar")) {
@@ -89,7 +89,7 @@ async function modifyProfile(_, args, context, info) {
         officePhone: copyValueToObjectIfDefined(args.data.officePhone),
         titleEn: copyValueToObjectIfDefined(args.data.titleEn),
         titleFr: copyValueToObjectIfDefined(args.data.titleFr),
-        isAdmin: copyValueToObjectIfDefined(args.data.isAdmin),
+        role: copyValueToObjectIfDefined(args.data.role),
     };
 
     if (propertyExists(args.data, "avatar")) {

--- a/src/Service_Mesh/handler.js
+++ b/src/Service_Mesh/handler.js
@@ -23,10 +23,10 @@ async function msgHandler(msg, success) {
                 gcID: messageBody.gcID,
                 name: messageBody.name,
                 email: messageBody.email,
-                isAdmin: messageBody.isAdmin
+                role: (messageBody.isAdmin) ? "Admin" : "User"
             };
             try {
-                await createProfile(null, args, context, "{gcID, name, email, isAdmin}");
+                await createProfile(null, args, context, "{gcID, name, email, role}");
                 success(true);
             } catch (err) {
                 if (err instanceof GraphQLError) {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -154,7 +154,7 @@ input ModifyProfileInput {
   titleEn: String 
   titleFr: String 
   team: TeamInput 
-  isAdmin: Boolean
+  role: UserRole
 }
 
 input ModifyTeamInput {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -82,7 +82,7 @@ type Profile {
   ownerOfTeams: [Team!]!
   outstandingApprovals: [Approval!]!
   submittedApprovals: [Approval!]!
-  isAdmin: Boolean! @onlyAdmin
+  role: UserRole! @onlyAdmin
 }
 
 type Address {
@@ -240,6 +240,11 @@ enum OrgType {
     University
     College
     Other
+}
+
+enum UserRole {
+    User
+    Admin
 }
 
 input gcIDProfileInput {


### PR DESCRIPTION
## :warning: A fresh install is required for this branch. Adds new required field that previous nodes won't have. ⚠️ 

## Description

Reworked the previous admin functionality from ```isAdmin: Boolean``` to ```role``` field that takes enum UserRole. 

Fixes #91 

## Type of change

- [ ] Breaking change 

## How Has This Been Tested?

- [ ] In graphql playground, run modifyProfile mutation on a separate user using a token from a user with ```role: Admin```. The mutation will go through and add the changes.
- [ ] In graphql playground, run modifyProfile mutation on a separate user using a token from a user with ```role: User```. The mutation will not be allowed to go through.

