### PR TITLE
Ability to query and create Integration objects

### DIFF
--- a/prisma/datamodel.graphql
+++ b/prisma/datamodel.graphql
@@ -87,7 +87,28 @@ type Integration {
     integrationID: String
     source: IntegrationSources!
     lastSync: String!
-    changes: Profile
+    changes: Changes @relation(name: "IncomingChanges" onDelete: CASCADE)
+}
+
+type Changes {
+    id: ID! @unique
+    name: String
+    email: String
+    avatar: String
+    mobilePhone: String
+    officePhone: String
+    address: ChangesAddress @relation(name: "ChangesAddress" onDelete: CASCADE)
+    titleEn: String
+    titleFr: String
+}
+
+type ChangesAddress {
+  id: ID! @unique
+  streetAddress: String
+  city: String
+  province: String
+  postalCode: String
+  country: String
 }
 
 enum Status {

--- a/src/Middleware/integrationCreation.js
+++ b/src/Middleware/integrationCreation.js
@@ -1,0 +1,257 @@
+const { getProfile, checkForDirective, } = require("./common");
+const { copyValueToObjectIfDefined, removeNullKeys, isEmpty } = require("../Resolvers/helper/objectHelper");
+const { getNewAddressFromArgs } = require("../Resolvers/helper/addressHelper");
+
+/*-------------------------------------------------------------------------
+With new integrations into PaaS, save record of user using external source
+ - Checks for additional context header: integrationsource
+ - Only one data object per user
+ - Update object if exists
+--------------------------------------------------------------------------*/
+
+// Create integration object
+async function createIntegration(_, args, context) {
+
+  // Get the user's profile information to compare
+  const currentProfile = await getProfile(context, args);
+
+  const info = `{
+      id
+      gcID
+      source
+      integrationID
+      lastSync
+      changes {
+        name
+        email
+        avatar
+        mobilePhone
+        officePhone
+        titleEn
+        titleFr
+      }
+    }`;
+
+  // Assign unique integrationID if supplied from context
+  var integrationID = null;
+  if (context.req.headers.integrationid) {
+    integrationID = context.req.headers.integrationid
+  }
+
+  // Create data object for mutation
+  // Only add information to changes if it differs from current profile information
+  const data = removeNullKeys({
+    gcID: Number(args.gcID),
+    source: context.req.headers.integrationsource,
+    integrationID: integrationID,
+    lastSync: await Date.now().toString(),
+    changes: {
+      create: {
+        name: (args.data.name != currentProfile.name) ? args.data.name : null,
+        email: (args.data.email != currentProfile.email) ? args.data.email : null,
+        avatar: (args.data.avatar != currentProfile.avatar) ? args.data.avatar : null,
+        mobilePhone: (args.data.mobilePhone != currentProfile.mobilePhone) ? args.data.mobilePhone : null,
+        officePhone: (args.data.officePhone != currentProfile.officePhone) ? args.data.officePhone : null,
+        titleEn: (args.data.titleEn != currentProfile.titleEn) ? args.data.titleEn : null,
+        titleFr: (args.data.titleFr != currentProfile.titleFr) ? args.data.titleFr : null,
+        address: (args.data.address) ? {
+          create: {
+            streetAddress: (args.data.address.streetAddress != currentProfile.address.streetAddress) ? args.data.address.streetAddress : null,
+            city: (args.data.address.city != currentProfile.address.city) ? args.data.address.city : null,
+            province: (args.data.address.province != currentProfile.address.province) ? args.data.address.province : null,
+            postalCode: (args.data.address.postalCode != currentProfile.address.postalCode) ? args.data.address.postalCode : null,
+            country: (args.data.address.country != currentProfile.address.country) ? args.data.address.country : null,
+          }
+        } : null
+      }
+    },
+  });
+
+  // Fire off mutation
+  return await context.prisma.mutation.createIntegration({
+    data
+  }, info)
+    .then((result) => {
+      return result;
+    })
+    .catch((e) =>{
+      return e;
+    });
+  
+}
+
+// Update existing integration object
+async function updateIntegration(_, args, context, integrationObject) {
+
+  // Get the user's profile information to compare
+  const currentProfile = await getProfile(context, args);
+
+  const info = `{
+      id
+      gcID
+      source
+      integrationID
+      lastSync
+      changes {
+        name
+        email
+        avatar
+        mobilePhone
+        officePhone
+        titleEn
+        titleFr
+      }
+    }`;
+
+  // Assign unique integrationID if supplied from context
+  var integrationID = null;
+  if (context.req.headers.integrationid) {
+    integrationID = context.req.headers.integrationid
+  }
+
+  // Check if the ChangesAddress object needs to be created or updated
+  // Only display changes in information
+  var changesAddressObject;
+  if(integrationObject.changes && integrationObject.changes.address && args.data.address) {
+    changesAddressObject = {
+      update: {
+        streetAddress: (args.data.address.streetAddress != currentProfile.address.streetAddress) ? args.data.address.streetAddress : null,
+        city: (args.data.address.city != currentProfile.address.city) ? args.data.address.city : null,
+        province: (args.data.address.province != currentProfile.address.province) ? args.data.address.province : null,
+        postalCode: (args.data.address.postalCode != currentProfile.address.postalCode) ? args.data.address.postalCode : null,
+        country: (args.data.address.country != currentProfile.address.country) ? args.data.address.country : null,
+      }
+    }
+  } else {
+    changesAddressObject = (args.data.address) ? {
+      create: {
+        streetAddress: (args.data.address.streetAddress != currentProfile.address.streetAddress) ? args.data.address.streetAddress : null,
+        city: (args.data.address.city != currentProfile.address.city) ? args.data.address.city : null,
+        province: (args.data.address.province != currentProfile.address.province) ? args.data.address.province : null,
+        postalCode: (args.data.address.postalCode != currentProfile.address.postalCode) ? args.data.address.postalCode : null,
+        country: (args.data.address.country != currentProfile.address.country) ? args.data.address.country : null,
+      }
+    } : null
+  }
+
+  // If address object has no new information to show, delete it
+  if(changesAddressObject != null && isEmpty(removeNullKeys(changesAddressObject)) && integrationObject.changes && integrationObject.changes.address){
+    await context.prisma.mutation.deleteChangesAddress({
+      where: {
+        id: integrationObject.changes.address.id
+      }
+    });
+    changesAddressObject = null;
+  }
+
+  // Create Changes object for mutation
+  // Only add information to changes if it differs from current profile information
+  const changesObjectData = {
+    name: (args.data.name != currentProfile.name) ? args.data.name : null,
+    email: (args.data.email != currentProfile.email) ? args.data.email : null,
+    avatar: (args.data.avatar != currentProfile.avatar) ? args.data.avatar : null,
+    mobilePhone: (args.data.mobilePhone != currentProfile.mobilePhone) ? args.data.mobilePhone : null,
+    officePhone: (args.data.officePhone != currentProfile.officePhone) ? args.data.officePhone : null,
+    titleEn: (args.data.titleEn != currentProfile.titleEn) ? args.data.titleEn : null,
+    titleFr: (args.data.titleFr != currentProfile.titleFr) ? args.data.titleFr : null,
+    address: changesAddressObject
+  };
+
+  // Determine if creating new or updating existing object
+  var changesObject;
+  if(integrationObject.changes) {
+    changesObject = { update: changesObjectData };
+  } else {
+    changesObject = { create: changesObjectData };
+  }
+  
+  // Remove existing Changes object if all fields are null
+  if(isEmpty(removeNullKeys(changesObject)) && integrationObject.changes){
+    await context.prisma.mutation.deleteChanges({
+      where: {
+        id: integrationObject.changes.id
+      }
+    });
+    changesObject = null;
+  }
+
+  // Format data for mutation
+  const data = {
+    integrationID: integrationID,
+    lastSync: await Date.now().toString(),
+    changes: changesObject,
+  };
+
+  // Fire off mutation
+  return await context.prisma.mutation.updateIntegration({
+    where: {
+      id: integrationObject.id
+    },
+    data
+  }, info)
+    .then((result) => {
+      return result;
+    })
+    .catch((e) =>{
+      return e;
+    });
+}
+
+async function getExistingIntegrations(context, gcID, source) {
+  return await context.prisma.query.integrations({
+    where: {
+      gcID,
+      source
+    },
+  },
+    `{
+      id
+      changes {
+        id
+        address {
+          id
+        }
+      }
+    }`
+  );
+}
+
+// Based on user information and source
+// Determine if new integration needs to be created or update a previusly created integration
+async function generateIntegration(context, args) {
+  // does integration exist
+  var integration = await getExistingIntegrations(context, Number(args.gcID), context.req.headers.integrationsource);
+  
+  if(integration.length > 0){
+    await updateIntegration(null, args, context, integration[0])
+      .catch((e) => {
+        // eslint-disable-next-line no-console
+        console.log(e);
+      });
+  } else {
+    await createIntegration(null, args, context)
+      .catch((e) => {
+        // eslint-disable-next-line no-console
+        console.log(e);
+      });
+  }
+  return;
+}
+
+// Check if additonal information has been passed -> context.req.headers.integrationsource
+// If not - continue business as usual
+const hasIntegrationSource = async (resolve, root, args, context, info) => {
+  if(context.req.headers.integrationsource) {
+    await Promise.all(
+      [
+        generateIntegration(context, args),
+      ]);
+      return await resolve(root, args, context, info);
+  } else {
+    return await resolve(root, args, context, info);
+  }
+};
+
+module.exports = {
+  hasIntegrationSource
+};

--- a/src/Resolvers/Query.js
+++ b/src/Resolvers/Query.js
@@ -146,6 +146,19 @@ async function integration(_, args, context, info){
   return await getGEDSInfo(args.email);
 }
 
+function integrationData(_, args, context, info) {
+  return context.prisma.query.integrations(
+    {
+      where: {
+        gcID: copyValueToObjectIfDefined(args.gcID),
+        source: copyValueToObjectIfDefined(args.source),
+      },
+      skip: copyValueToObjectIfDefined(args.skip),
+      first: copyValueToObjectIfDefined(args.first),
+    },
+    info,
+  );
+}
 
 module.exports = {
   search,
@@ -154,5 +167,6 @@ module.exports = {
   teams,
   organizations,
   approvals,
+  integrationData,
   integration
 };

--- a/src/Resolvers/helper/objectHelper.js
+++ b/src/Resolvers/helper/objectHelper.js
@@ -40,10 +40,21 @@ function cloneObject(object){
   return JSON.parse(JSON.stringify(object));
 }
 
+function isEmpty(obj) {
+  for(var prop in obj) {
+    if(obj.hasOwnProperty(prop)) {
+      return false;
+    }
+  }
+
+  return JSON.stringify(obj) === JSON.stringify({});
+}
+
 module.exports = {
   copyValueToObjectIfDefined,
   propertyRequired,
   propertyExists,
   removeNullKeys,
-  cloneObject
+  cloneObject,
+  isEmpty
 };

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ const { getDefaults } = require("./Resolvers/helper/default_setup");
 const { applyMiddleware } = require("graphql-middleware");
 const { profileApprovalRequired } = require("./Middleware/profileApprovalCreation");
 const { teamApprovalRequired } = require("./Middleware/teamApprovalCreation");
+const { hasIntegrationSource } = require("./Middleware/integrationCreation");
 const { allowedToModifyProfile, allowedToModifyApproval, allowedToModifyTeam, mustbeAuthenticated, mustBeAdmin, adminOnlyField } = require("./Middleware/authMiddleware");
 
 const resolvers = {
@@ -77,6 +78,12 @@ const adminOnlyApplications =
   }
 }
 
+const profileIntegrationApplications = {
+  Mutation: {
+    modifyProfile: hasIntegrationSource
+  },
+};
+
 const typeDefs = gql`${fs.readFileSync(__dirname.concat("/schema.graphql"), "utf8")}`;
 
 const schemaBeforeMiddleware = makeExecutableSchema({
@@ -102,7 +109,8 @@ const schema = applyMiddleware(
   ownershipRequiredApplications,
   profileApprovalRequiredApplications,
   teamApprovalRequiredApplications,
-  adminOnlyApplications
+  adminOnlyApplications,
+  profileIntegrationApplications
 );
 
 const server = new ApolloServer({

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -37,6 +37,7 @@ scalar JSONObject
 type Query {
   search(partialName:String, number: Int):[Profile!]!
   integration(email: Email!, source: IntegrationSources!):JSONObject!
+  integrationData(gcID: ID, source: IntegrationSources, skip: Int, first: Int): [Integration!]!
   profiles(gcID: ID, name: String, email: Email, mobilephone: String, officePhone: String , titleEn: String, titleFr: String, skip: Int, first: Int): [Profile!]!,
   addresses(id: ID, streetAddress: String, city: String, province: String, postalCode: String, country: String, skip: Int, first: Int): [Address!]!,
   teams(id: ID, nameEn: String, nameFr: String, skip: Int, first: Int): [Team!]!,
@@ -229,7 +230,7 @@ type Integration {
     integrationID: String
     source: IntegrationSources!
     lastSync: String!
-    changes: Profile
+    changes: Changes
 }
 
 input IntegrationInput {
@@ -237,7 +238,51 @@ input IntegrationInput {
     integrationID: String
     source: IntegrationSources!
     lastSync: String!
-    changes: ModifyProfileInput
+    changes: ChangesInput
+}
+
+type Changes {
+    id: ID!
+    name: String
+    email: String
+    avatar: String
+    mobilePhone: PhoneNumber
+    officePhone: PhoneNumber
+    address: ChangesAddress
+    titleEn: String
+    titleFr: String
+    team: Team
+    ownershipOfTeam: Team
+}
+
+input ChangesInput {
+    name: String
+    email: String
+    avatar: String
+    mobilePhone: PhoneNumber
+    officePhone: PhoneNumber
+    address: ChangesAddressInput
+    titleEn: String
+    titleFr: String
+    team: TeamInput
+    ownershipOfTeam: TeamInput
+}
+
+type ChangesAddress {
+  id: ID!
+  streetAddress: String
+  city: String
+  province: String
+  postalCode: String
+  country: String
+}
+
+input ChangesAddressInput {
+  streetAddress: String
+  city: String
+  province: String
+  postalCode: PostalCode
+  country: String
 }
 
 enum Status {


### PR DESCRIPTION
# Description

Added middleware to create/update Integration objects when `integrationsource: <SOURCE>` is passed with modifyProfile mutation. Additional `integrationid: <ID>` can be passed to save unique identifier of user in integration's DB.

Also adds ability to query Integration objects. 
`query {
  integrationData {
    id
    gcID
    integrationID
    source
    lastSync
    changes {
      id
      name
      email
      titleEn
      titleFr
      mobilePhone
      officePhone
      address {
        id
        streetAddress
        city
        postalCode
        province
        country
      }
    }
  }
}`

# Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [ ] Run modifyProfile mutation without `integrationsource` in headers. Profile should be modified normally.
- [ ]  Run modifyProfile mutation with `integrationsource: "GEDS"` in headers. Integration object will be created showing current changes to profile be made in mutation. 
